### PR TITLE
Added console module based on consol.h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ogc-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ogc-rs/Cargo.toml
+++ b/ogc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogc-rs"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["rust-wii"]
 edition = "2018"
 

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -1,0 +1,65 @@
+//! The ``console`` module of ``ogc-rs``.
+//!
+//! This module implements a safe wrapper around the console functions.
+
+use std::{ffi};
+use utils;
+
+struct Console {
+}
+
+impl Console {
+    pub fn init(xstart: i32, ystart: i32, xres: i32, yres: i32, stride: i32) -> Console {
+        unsafe {
+            ogc_sys::CON_Init(
+                mem_k0_to_k1(ogc_sys::SYS_AllocateFramebuffer(
+                    ogc_sys::VIDEO_GetPreferredMode(ptr::null()),
+                )),
+                xstart,
+                ystart,
+                xres,
+                yres,
+                stride,
+            );
+        }
+
+        Console(())
+    }
+
+    pub fn init_stdout(xorigin: i32, yorigin: i32, width: i32, height: i32) -> Result<()> {
+        unsafe {
+            let init = ogc_sys::CON_InitEx(ogc_sys::VIDEO_GetPreferredMode(ptr::null()), xorigin, yorigin, width, height);
+        
+            match init {
+                -1 => Err(OgcError::Console("Message")),
+                0 => Ok(())
+            }
+        }
+    }
+
+    pub fn enable_gecko(channel: i32, safe: i32) -> () {
+        unsafe {
+            ogc_sys::CON_EnableGecko(channel, safe);
+        }
+   }
+
+   pub fn get_metrics() -> (i32, i32) {
+       let mut coords: (i32, i32) = (0,0);
+
+       unsafe {
+           ogc_sys::CON_GetMetrics(coords.0, coords.1);
+       }
+
+       coords
+   }
+
+    pub fn get_position() -> (i32, i32) {
+        let mut coords: (i32, i32) = (0,0);
+        
+        unsafe {
+            ogc_sys::CON_GetPosition(coords.0, coords.1);
+        }
+
+        coords
+    }
+}

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -33,7 +33,9 @@ impl Console {
             );
 
             match init {
-                -1 => Err(OgcError::Console("Failed to allocate memory for framebuffer!".into())),
+                -1 => Err(OgcError::Console(
+                    "Failed to allocate memory for framebuffer!".into(),
+                )),
                 0 => Ok(()),
             }
         }

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -33,7 +33,7 @@ impl Console {
             );
 
             match init {
-                -1 => Err(OgcError::Console("con_initex failed".into())),
+                -1 => Err(OgcError::Console("Failed to allocate memory for framebuffer!".into())),
                 0 => Ok(()),
             }
         }

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -2,60 +2,65 @@
 //!
 //! This module implements a safe wrapper around the console functions.
 
-use std::{ffi};
-use utils;
+use crate::mem_k0_to_k1;
+use std::ptr;
 
-struct Console {
-}
+struct Console(());
 
 impl Console {
+    /// Initializes the console subsystem with given parameters.
     pub fn init(xstart: i32, ystart: i32, xres: i32, yres: i32, stride: i32) -> Console {
         unsafe {
-            ogc_sys::CON_Init(
-                mem_k0_to_k1(ogc_sys::SYS_AllocateFramebuffer(
-                    ogc_sys::VIDEO_GetPreferredMode(ptr::null()),
-                )),
-                xstart,
-                ystart,
-                xres,
-                yres,
-                stride,
-            );
+            let framebuffer = mem_k0_to_k1(ogc_sys::SYS_AllocateFramebuffer(
+                ogc_sys::VIDEO_GetPreferredMode(ptr::null()),
+            ));
+
+            ogc_sys::CON_Init(framebuffer, xstart, ystart, xres, yres, stride);
         }
 
         Console(())
     }
 
+    /// Initialize stdout console.
     pub fn init_stdout(xorigin: i32, yorigin: i32, width: i32, height: i32) -> Result<()> {
         unsafe {
-            let init = ogc_sys::CON_InitEx(ogc_sys::VIDEO_GetPreferredMode(ptr::null()), xorigin, yorigin, width, height);
-        
+            let init = ogc_sys::CON_InitEx(
+                ogc_sys::VIDEO_GetPreferredMode(ptr::null()),
+                xorigin,
+                yorigin,
+                width,
+                height,
+            );
+
             match init {
-                -1 => Err(OgcError::Console("Message")),
-                0 => Ok(())
+                -1 => Err(OgcError::Console("con_initex failed".into())),
+                0 => Ok(()),
             }
         }
     }
 
-    pub fn enable_gecko(channel: i32, safe: i32) -> () {
+    /// Enable or disable the USB gecko console.
+    pub fn enable_gecko(channel: i32, safe: i32) {
         unsafe {
             ogc_sys::CON_EnableGecko(channel, safe);
         }
-   }
+    }
 
-   pub fn get_metrics() -> (i32, i32) {
-       let mut coords: (i32, i32) = (0,0);
+    /// Retrieve the columns and rows of the current console
+    pub fn get_metrics() -> (i32, i32) {
+        let mut coords: (i32, i32) = (0, 0);
 
-       unsafe {
-           ogc_sys::CON_GetMetrics(coords.0, coords.1);
-       }
+        unsafe {
+            ogc_sys::CON_GetMetrics(coords.0, coords.1);
+        }
 
-       coords
-   }
+        coords
+    }
 
+    /// Retrieve the current cursor position of the current console.
     pub fn get_position() -> (i32, i32) {
-        let mut coords: (i32, i32) = (0,0);
-        
+        let mut coords: (i32, i32) = (0, 0);
+
         unsafe {
             ogc_sys::CON_GetPosition(coords.0, coords.1);
         }

--- a/ogc-rs/src/error.rs
+++ b/ogc-rs/src/error.rs
@@ -15,7 +15,7 @@ impl fmt::Debug for OgcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OgcError::Network(err) => write!(f, "[ OGC - Network ]: {}", err),
-            OgcError::Console(err) => write!(f, "[OGC - Console]: {}", err),
+            OgcError::Console(err) => write!(f, "[ OGC - Console ]: {}", err),
         }
     }
 }
@@ -24,7 +24,7 @@ impl fmt::Display for OgcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OgcError::Network(err) => write!(f, "[ OGC - Network ]: {}", err),
-            OgcError::Console(err) => write!(f, "[ OGC - Console]: {}", err),
+            OgcError::Console(err) => write!(f, "[ OGC - Console ]: {}", err),
         }
     }
 }

--- a/ogc-rs/src/error.rs
+++ b/ogc-rs/src/error.rs
@@ -8,12 +8,14 @@ pub type Result<T> = std::result::Result<T, OgcError>;
 /// Custom Error Type
 pub enum OgcError {
     Network(String),
+    Console(String),
 }
 
 impl fmt::Debug for OgcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OgcError::Network(err) => write!(f, "[ OGC - Network ]: {}", err),
+            OgcError::Console(err) => write!(f, "[OGC - Console]: {}", err),
         }
     }
 }
@@ -22,6 +24,7 @@ impl fmt::Display for OgcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             OgcError::Network(err) => write!(f, "[ OGC - Network ]: {}", err),
+            OgcError::Console(err) => write!(f, "[ OGC - Console]: {}", err),
         }
     }
 }

--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -29,6 +29,9 @@ pub use error::{OgcError, Result};
 /// Networking Implementation
 pub mod network;
 
+/// Console Implementation
+pub mod console;
+
 /// Utility Functions
 pub mod utils;
 pub use utils::*;

--- a/ogc-rs/src/network.rs
+++ b/ogc-rs/src/network.rs
@@ -356,7 +356,7 @@ impl Socket {
         }
     }
 
-    /// The accept function is called by a TCP server to accept client requests and 
+    /// The accept function is called by a TCP server to accept client requests and
     /// to establish actual connection.
     pub fn accept(&self, socket_addr: SocketAddress, address_length: &mut u32) -> Result<i32> {
         unsafe {

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -1,5 +1,7 @@
 //! Utility Functions to convert between types.
+
 use std::ffi::c_void;
+
 /// Converts a raw *mut u8 into a String.
 pub fn raw_to_string(raw: *mut u8) -> String {
     unsafe {
@@ -19,7 +21,7 @@ pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
     }
 }
 
-///Converts uncached memory into cached memory (K0 type into K1 type)
+/// Converts uncached memory into cached memory (K0 type into K1 type).
 pub fn mem_k0_to_k1(x: *mut c_void) -> *mut c_void {
     ((x as u32) + (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
 }

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -1,5 +1,5 @@
 //! Utility Functions to convert between types.
-
+use std::ffi::c_void;
 /// Converts a raw *mut u8 into a String.
 pub fn raw_to_string(raw: *mut u8) -> String {
     unsafe {
@@ -17,4 +17,9 @@ pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
             String::from_utf8(r.to_vec()).unwrap()
         }).collect()
     }
+}
+
+///Converts uncached memory into cached memory (K0 type into K1 type)
+pub fn mem_k0_to_k1(x: *mut c_void) -> *mut c_void {
+    ((x as u32) + (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
 }

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -14,10 +14,13 @@ pub fn raw_to_string(raw: *mut u8) -> String {
 pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
     unsafe {
         let slice = std::slice::from_raw_parts(raw, 2);
-        slice.into_iter().map(|x: &*mut u8| {
-            let r = std::slice::from_raw_parts(*x, 1);
-            String::from_utf8(r.to_vec()).unwrap()
-        }).collect()
+        slice
+            .into_iter()
+            .map(|x: &*mut u8| {
+                let r = std::slice::from_raw_parts(*x, 1);
+                String::from_utf8(r.to_vec()).unwrap()
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
This pull from the console branch adds the `console` module to `ogc-rs`

Console implements all functionality from `consol.h` from `libogc` through `ogc-sys`
This includes:

- `CON_GeckoEnable` [`Console::enable_gecko`] (Enable or Disable the USB Gecko Console)
- `CON_GetMetrics` [`Console::get_metrics`] (Retrieves current number of rows and columns)
- `CON_GetPosition` [`Console::get_position`] (Gets the cursor position)
- `CON_Init` [`Console::init`] (Inits the console module)
- `CON_InitEx` [`Console::init_stdout`] (Inits the stdout console on screen)
- `OgcError::Console` (An OgcError type for Console functions)

This branch also adds in `mem_k0_to_k1` to `utils.rs` for converting C Void Pointers from uncached to cached memory as required by the framebuffer.