### PR TITLE
Add OS functions based on system.h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,12 +48,12 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogc-sys 0.1.1",
+ "ogc-sys 0.2.0",
 ]
 
 [[package]]
 name = "ogc-sys"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "libc 0.2.56 (git+https://github.com/rust-wii/libc.git?branch=wii)",
 ]

--- a/ogc-rs/README.md
+++ b/ogc-rs/README.md
@@ -7,6 +7,7 @@
 * ``network``: Provides TCP networking for the Wii.
 * ``audio``: Provides functions for audio on the Wii.
 * ``fs``: Provides functions for manipulating the filesystem on the Wii.
+* ``system``: Provides OS functions for the Wii.
 * ``console``: Provides console functions for the Wii.
 * ``input``: Provides an interface for reading input from devices on the Wii.
 * ``video``: Provides functions for video output on the Wii.

--- a/ogc-rs/src/audio.rs
+++ b/ogc-rs/src/audio.rs
@@ -8,8 +8,6 @@ use std::{mem, ptr};
 /// Represents the audio service.
 /// No audio control can be done until an instance of this struct is created.
 /// This service can only be created once!
-///
-/// The service exits when all instances of this struct go out of scope.
 pub struct Audio(());
 
 /// The play state of the ``audio`` service.

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements a safe wrapper around the console functions.
 
-use crate::{mem_k0_to_k1, OgcError, Result};
+use crate::{mem_cached_to_uncached, OgcError, Result};
 use std::ptr;
 
 pub struct Console(());
@@ -11,8 +11,8 @@ impl Console {
     /// Initializes the console subsystem with given parameters.
     pub fn init(xstart: i32, ystart: i32, xres: i32, yres: i32, stride: i32) -> Console {
         unsafe {
-            let framebuffer = mem_k0_to_k1(ogc_sys::SYS_AllocateFramebuffer(
-                ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()),
+            let framebuffer = mem_cached_to_uncached!(ogc_sys::SYS_AllocateFramebuffer(
+                ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut())
             ));
 
             ogc_sys::CON_Init(framebuffer, xstart, ystart, xres, yres, stride);

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -5,8 +5,12 @@
 use crate::{mem_cached_to_uncached, OgcError, Result};
 use std::ptr;
 
+/// Represents the console service.
+/// No console control can be done until an instance of this struct is created.
+/// This service can only be created once!
 pub struct Console(());
 
+/// Implementation of the console service.
 impl Console {
     /// Initializes the console subsystem with given parameters.
     pub fn init(xstart: i32, ystart: i32, xres: i32, yres: i32, stride: i32) -> Console {
@@ -49,7 +53,7 @@ impl Console {
         }
     }
 
-    /// Retrieve the columns and rows of the current console
+    /// Retrieve the columns and rows of the current console.
     pub fn get_metrics() -> (i32, i32) {
         let coords: (i32, i32) = (0, 0);
 

--- a/ogc-rs/src/error.rs
+++ b/ogc-rs/src/error.rs
@@ -10,6 +10,7 @@ pub enum OgcError {
     Network(String),
     Audio(String),
     Console(String),
+    System(String),
 }
 
 impl fmt::Debug for OgcError {
@@ -18,6 +19,7 @@ impl fmt::Debug for OgcError {
             OgcError::Network(err) => write!(f, "[ OGC - Network ]: {}", err),
             OgcError::Audio(err) => write!(f, "[ OGC - Audio ]: {}", err),
             OgcError::Console(err) => write!(f, "[ OGC - Console ]: {}", err),
+            OgcError::System(err) => write!(f, "[ OGC - System ]: {}", err),
         }
     }
 }
@@ -28,6 +30,7 @@ impl fmt::Display for OgcError {
             OgcError::Network(err) => write!(f, "[ OGC - Network ]: {}", err),
             OgcError::Audio(err) => write!(f, "[ OGC - Audio ]: {}", err),
             OgcError::Console(err) => write!(f, "[ OGC - Console ]: {}", err),
+            OgcError::System(err) => write!(f, "[ OGC - System ]: {}", err),
         }
     }
 }

--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -35,6 +35,9 @@ pub mod audio;
 // Console Implementation
 pub mod console;
 
+// System Implementation
+pub mod system;
+
 // Utility Functions
 pub mod utils;
-use utils::*;
+pub use utils::*;

--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -18,9 +18,9 @@
 #![crate_type = "rlib"]
 #![crate_name = "ogc"]
 
-pub use bitflags::bitflags;
-pub use enum_primitive_derive::Primitive;
-pub use num_traits::cast::{FromPrimitive, ToPrimitive};
+use bitflags::bitflags;
+use enum_primitive_derive::Primitive;
+use num_traits::cast::{FromPrimitive, ToPrimitive};
 
 /// Custom Error Implementation
 pub mod error;
@@ -37,4 +37,4 @@ pub mod console;
 
 /// Utility Functions
 pub mod utils;
-pub use utils::*;
+use utils::*;

--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -22,19 +22,19 @@ use bitflags::bitflags;
 use enum_primitive_derive::Primitive;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 
-/// Custom Error Implementation
+// Custom Error Implementation
 pub mod error;
 pub use error::{OgcError, Result};
 
-/// Networking Implementation
+// Networking Implementation
 pub mod network;
 
-/// Audio Implementation
+// Audio Implementation
 pub mod audio;
 
-/// Console Implementation
+// Console Implementation
 pub mod console;
 
-/// Utility Functions
+// Utility Functions
 pub mod utils;
 use utils::*;

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -42,6 +42,56 @@ pub enum MemoryProtectChannels {
     All = 4,
 }
 
+/// System Font Header Structure
+pub struct FontHeader {
+    pub font_type: u16,
+    pub first_char: u16,
+    pub last_char: u16,
+    pub inval_char: u16,
+    pub asc: u16,
+    pub desc: u16,
+    pub width: u16,
+    pub leading: u16,
+    pub cell_dimensions: (u16, u16),
+    pub sheet_size: u32,
+    pub sheet_format: u16,
+    pub sheet_colrow: (u16, u16),
+    pub sheet_dimensions: (u16, u16),
+    pub width_table: u16,
+    pub sheet_image: u32,
+    pub sheet_fullsize: u32,
+}
+
+impl Into<*mut ogc_sys::sys_fontheader> for &mut FontHeader {
+    fn into(self) -> *mut ogc_sys::sys_fontheader {
+        Box::into_raw(Box::new(ogc_sys::sys_fontheader {
+            font_type: self.font_type,
+            first_char: self.first_char,
+            last_char: self.last_char,
+            inval_char: self.inval_char,
+            asc: self.asc,
+            desc: self.desc,
+            width: self.width,
+            leading: self.leading,
+            cell_width: self.cell_dimensions.0,
+            cell_height: self.cell_dimensions.1,
+            sheet_size: self.sheet_size,
+            sheet_format: self.sheet_format,
+            sheet_column: self.sheet_colrow.0,
+            sheet_row: self.sheet_colrow.1,
+            sheet_width: self.sheet_dimensions.0,
+            sheet_height: self.sheet_dimensions.1,
+            width_table: self.width_table,
+            sheet_image: self.sheet_image,
+            sheet_fullsize: self.sheet_fullsize,
+            c0: 0,
+            c1: 0,
+            c2: 0,
+            c3: 0,
+        }))
+    }
+}
+
 /// Implementation of the system service.
 impl System {
     /// Create and initialize sysalarm structure.
@@ -155,81 +205,80 @@ impl System {
         }
     }
 
+    /// Init Font
+    pub fn init_font(font_header: &mut FontHeader) {
+        unsafe {
+            let _ = ogc_sys::SYS_InitFont(font_header.into());
+        }
+    }
+
+    /// Get Font Texel
+    pub fn get_font_texel(c: i32, image: *mut c_void, position: i32, stride: i32, width: &mut i32) {
+        unsafe {
+            ogc_sys::SYS_GetFontTexel(c, image, position, stride, width);
+        }
+    }
+
+    /// Get Font Texture
+    pub fn get_font_texture(c: i32, image: *mut *mut c_void, xpos: &mut i32, ypos: &mut i32, width: &mut i32) {
+        unsafe {
+            ogc_sys::SYS_GetFontTexture(c, image, xpos, ypos, width);
+        }
+    }
+
     /// Get Font Encoding
     pub fn get_font_encoding() -> u32 {
-        unsafe {
-            ogc_sys::SYS_GetFontEncoding()
-        }
+        unsafe { ogc_sys::SYS_GetFontEncoding() }
     }
 
     /// Get Arena 1 Lo
     pub fn get_arena_1_lo() -> *mut c_void {
-        unsafe {
-            ogc_sys::SYS_GetArena1Lo()
-        }
+        unsafe { ogc_sys::SYS_GetArena1Lo() }
     }
 
     /// Set Arena 1 Lo
     pub fn set_arena_1_lo(new_lo: *mut c_void) {
-        unsafe {
-            ogc_sys::SYS_SetArena1Lo(new_lo)
-        }
+        unsafe { ogc_sys::SYS_SetArena1Lo(new_lo) }
     }
 
     /// Get Arena 1 Hi
     pub fn get_arena_1_hi() -> *mut c_void {
-        unsafe {
-            ogc_sys::SYS_GetArena1Hi()
-        }
+        unsafe { ogc_sys::SYS_GetArena1Hi() }
     }
 
     /// Set Arena 1 Hi
     pub fn set_arena_1_hi(new_hi: *mut c_void) {
-        unsafe {
-            ogc_sys::SYS_SetArena1Hi(new_hi)
-        }
+        unsafe { ogc_sys::SYS_SetArena1Hi(new_hi) }
     }
 
     /// Get Arena 1 Size
     pub fn get_arena_1_size() -> u32 {
-        unsafe {
-            ogc_sys::SYS_GetArena1Size()
-        }
+        unsafe { ogc_sys::SYS_GetArena1Size() }
     }
 
     /// Get Arena 2 Lo
     pub fn get_arena_2_lo() -> *mut c_void {
-        unsafe {
-            ogc_sys::SYS_GetArena2Lo()
-        }
+        unsafe { ogc_sys::SYS_GetArena2Lo() }
     }
 
     /// Set Arena 2 Lo
     pub fn set_arena_2_lo(new_lo: *mut c_void) {
-        unsafe {
-            ogc_sys::SYS_SetArena2Lo(new_lo)
-        }
+        unsafe { ogc_sys::SYS_SetArena2Lo(new_lo) }
     }
 
     /// Get Arena 2 Hi
     pub fn get_arena_2_hi() -> *mut c_void {
-        unsafe {
-            ogc_sys::SYS_GetArena2Hi()
-        }
+        unsafe { ogc_sys::SYS_GetArena2Hi() }
     }
 
     /// Set Arena 2 Hi
     pub fn set_arena_2_hi(new_hi: *mut c_void) {
-        unsafe {
-            ogc_sys::SYS_SetArena2Hi(new_hi)
-        }
+        unsafe { ogc_sys::SYS_SetArena2Hi(new_hi) }
     }
 
     /// Get Arena 2 Size
     pub fn get_arena_2_size() -> u32 {
-        unsafe {
-            ogc_sys::SYS_GetArena2Size()
-        }
+        unsafe { ogc_sys::SYS_GetArena2Size() }
     }
 
     /// Set Wireless ID
@@ -332,9 +381,7 @@ impl System {
 
     /// Get Hollywood Revision
     pub fn get_hollywood_revision() -> u32 {
-        unsafe {
-            ogc_sys::SYS_GetHollywoodRevision()
-        }
+        unsafe { ogc_sys::SYS_GetHollywoodRevision() }
     }
 
     /// Get system time.

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements a safe wrapper around the OS functions found in ``system.h``.
 
-use crate::{OgcError, Primitive, Result, ToPrimitive};
+use crate::{video::RenderConfig, OgcError, Primitive, Result, ToPrimitive};
 use std::ffi::c_void;
 use std::mem;
 use std::time::Duration;
@@ -94,6 +94,15 @@ impl Into<*mut ogc_sys::sys_fontheader> for &mut FontHeader {
 
 /// Implementation of the system service.
 impl System {
+    /// Allocate cacheline aligned memory for the external
+    /// framebuffer based on the rendermode object.
+    ///
+    /// This function returns a pointer to the framebuffer's startaddress which
+    /// is aligned to a 32 byte boundary.
+    pub fn allocate_framebuffer(render_mode: *mut RenderConfig) -> *mut c_void {
+        unsafe { ogc_sys::SYS_AllocateFramebuffer(render_mode.into()) }
+    }
+
     /// Create and initialize sysalarm structure.
     pub fn create_alarm(context: &mut u32) -> Result<()> {
         unsafe {
@@ -220,7 +229,13 @@ impl System {
     }
 
     /// Get Font Texture
-    pub fn get_font_texture(c: i32, image: *mut *mut c_void, xpos: &mut i32, ypos: &mut i32, width: &mut i32) {
+    pub fn get_font_texture(
+        c: i32,
+        image: *mut *mut c_void,
+        xpos: &mut i32,
+        ypos: &mut i32,
+        width: &mut i32,
+    ) {
         unsafe {
             ogc_sys::SYS_GetFontTexture(c, image, xpos, ypos, width);
         }

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -2,18 +2,343 @@
 //!
 //! This module implements a safe wrapper around the OS functions found in ``system.h``.
 
-use std::{mem, ptr};
+use crate::{OgcError, Primitive, Result, ToPrimitive};
+use std::ffi::c_void;
+use std::mem;
+use std::time::Duration;
 
 /// Represents the system service.
 /// The initialization of this service is done in the crt0 startup code.
 pub struct System(());
 
+/// OS Reset Types
+#[derive(Debug, Eq, PartialEq, Primitive)]
+pub enum ResetTypes {
+    Restart = 0,
+    HotReset = 1,
+    Shutdown = 2,
+    ReturnToMenu = 3,
+    PowerOff = 4,
+    PowerOffStandby = 5,
+    PowerOffIdle = 6,
+}
+
+/// OS Memory Protection Modes
+#[derive(Debug, Eq, PartialEq, Primitive)]
+pub enum MemoryProtectModes {
+    ProtectNone = 0,
+    ProtectRead = 1,
+    ProtectWrite = 2,
+    ProtectReadWrite = 1 | 2,
+}
+
+/// OS Memory Protection Channels
+#[derive(Debug, Eq, PartialEq, Primitive)]
+pub enum MemoryProtectChannels {
+    ChannelZero = 0,
+    ChannelOne = 1,
+    ChannelTwo = 2,
+    ChannelThree = 3,
+    All = 4,
+}
+
 /// Implementation of the system service.
 impl System {
+    /// Create and initialize sysalarm structure.
+    pub fn create_alarm(context: &mut u32) -> Result<()> {
+        unsafe {
+            let r = ogc_sys::SYS_CreateAlarm(context);
+
+            if r < 0 {
+                Err(OgcError::System("system failed to create alarm".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Cancel the alarm, but do not remove from the list of contexts.
+    pub fn cancel_alarm(context: u32) -> Result<()> {
+        unsafe {
+            let r = ogc_sys::SYS_CancelAlarm(context);
+
+            if r < 0 {
+                Err(OgcError::System("system failed to cancel alarm".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Remove the given alarm context from the list of contexts and destroy it.
+    pub fn remove_alarm(context: u32) -> Result<()> {
+        unsafe {
+            let r = ogc_sys::SYS_RemoveAlarm(context);
+
+            if r < 0 {
+                Err(OgcError::System("system failed to remove alarm".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Set the alarm parameters for a one-shot alarm, add to the list of alarms and start.
+    pub fn set_alarm<F>(context: u32, fire_time: Duration, callback: Box<F>) -> Result<()>
+    where
+        F: Fn(u32, *mut c_void) -> (),
+    {
+        unsafe {
+            // Convert Duration to timespec
+            let timespec: *const ogc_sys::timespec = &ogc_sys::timespec {
+                tv_sec: fire_time.as_secs() as i64,
+                tv_nsec: fire_time.as_nanos() as i32,
+                __bindgen_padding_0: 0,
+            };
+
+            // TODO: Check if this implementation can be changed.
+            let ptr = Box::into_raw(callback);
+            let code: extern "C" fn(alarm: u32, cb_arg: *mut c_void) = mem::transmute(ptr);
+            let r = ogc_sys::SYS_SetAlarm(context, timespec, Some(code), 0 as *mut c_void);
+
+            if r < 0 {
+                Err(OgcError::System("system failed to set alarm".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Set the alarm parameters for a periodic alarm, add to the list of alarms and start.
+    /// The alarm and interval persists as long as SYS_CancelAlarm() isn't called.
+    pub fn set_periodic_alarm<F>(
+        context: u32,
+        time_start: Duration,
+        time_period: Duration,
+        callback: Box<F>,
+    ) -> Result<()>
+    where
+        F: Fn(u32, *mut c_void) -> (),
+    {
+        unsafe {
+            // Convert Duration to timespec
+            let timespec_start: *const ogc_sys::timespec = &ogc_sys::timespec {
+                tv_sec: time_start.as_secs() as i64,
+                tv_nsec: time_start.as_nanos() as i32,
+                __bindgen_padding_0: 0,
+            };
+
+            let timespec_period: *const ogc_sys::timespec = &ogc_sys::timespec {
+                tv_sec: time_period.as_secs() as i64,
+                tv_nsec: time_period.as_nanos() as i32,
+                __bindgen_padding_0: 0,
+            };
+
+            // TODO: Check if this implementation can be changed.
+            let ptr = Box::into_raw(callback);
+            let code: extern "C" fn(alarm: u32, cb_arg: *mut c_void) = mem::transmute(ptr);
+            let r = ogc_sys::SYS_SetPeriodicAlarm(
+                context,
+                timespec_start,
+                timespec_period,
+                Some(code),
+                0 as *mut c_void,
+            );
+
+            if r < 0 {
+                Err(OgcError::System(
+                    "system failed to set periodic alarm".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Get Font Encoding
+    pub fn get_font_encoding() -> u32 {
+        unsafe {
+            ogc_sys::SYS_GetFontEncoding()
+        }
+    }
+
+    /// Get Arena 1 Lo
+    pub fn get_arena_1_lo() -> *mut c_void {
+        unsafe {
+            ogc_sys::SYS_GetArena1Lo()
+        }
+    }
+
+    /// Set Arena 1 Lo
+    pub fn set_arena_1_lo(new_lo: *mut c_void) {
+        unsafe {
+            ogc_sys::SYS_SetArena1Lo(new_lo)
+        }
+    }
+
+    /// Get Arena 1 Hi
+    pub fn get_arena_1_hi() -> *mut c_void {
+        unsafe {
+            ogc_sys::SYS_GetArena1Hi()
+        }
+    }
+
+    /// Set Arena 1 Hi
+    pub fn set_arena_1_hi(new_hi: *mut c_void) {
+        unsafe {
+            ogc_sys::SYS_SetArena1Hi(new_hi)
+        }
+    }
+
+    /// Get Arena 1 Size
+    pub fn get_arena_1_size() -> u32 {
+        unsafe {
+            ogc_sys::SYS_GetArena1Size()
+        }
+    }
+
+    /// Get Arena 2 Lo
+    pub fn get_arena_2_lo() -> *mut c_void {
+        unsafe {
+            ogc_sys::SYS_GetArena2Lo()
+        }
+    }
+
+    /// Set Arena 2 Lo
+    pub fn set_arena_2_lo(new_lo: *mut c_void) {
+        unsafe {
+            ogc_sys::SYS_SetArena2Lo(new_lo)
+        }
+    }
+
+    /// Get Arena 2 Hi
+    pub fn get_arena_2_hi() -> *mut c_void {
+        unsafe {
+            ogc_sys::SYS_GetArena2Hi()
+        }
+    }
+
+    /// Set Arena 2 Hi
+    pub fn set_arena_2_hi(new_hi: *mut c_void) {
+        unsafe {
+            ogc_sys::SYS_SetArena2Hi(new_hi)
+        }
+    }
+
+    /// Get Arena 2 Size
+    pub fn get_arena_2_size() -> u32 {
+        unsafe {
+            ogc_sys::SYS_GetArena2Size()
+        }
+    }
+
+    /// Set Wireless ID
+    pub fn set_wireless_id(channel: u32, id: u32) {
+        unsafe {
+            ogc_sys::SYS_SetWirelessID(channel, id);
+        }
+    }
+
+    /// Get Wireless ID
+    pub fn get_wireless_id(channel: u32) -> u32 {
+        unsafe { ogc_sys::SYS_GetWirelessID(channel) }
+    }
+
+    /// Start PMC
+    pub fn start_pmc(mcr0: u32, mcr1: u32) {
+        unsafe {
+            ogc_sys::SYS_StartPMC(mcr0, mcr1);
+        }
+    }
+
+    /// Dump PMC
+    pub fn dump_pmc() {
+        unsafe {
+            ogc_sys::SYS_DumpPMC();
+        }
+    }
+
+    /// Stop PMC
+    pub fn stop_pmc() {
+        unsafe {
+            ogc_sys::SYS_StopPMC();
+        }
+    }
+
+    /// Reset PMC
+    pub fn reset_pmc() {
+        unsafe {
+            ogc_sys::SYS_ResetPMC();
+        }
+    }
+
+    /// Reset System
+    pub fn reset_system(reset: i32, reset_type: ResetTypes, force_menu: i32) {
+        unsafe {
+            ogc_sys::SYS_ResetSystem(reset, reset_type.to_u32().unwrap(), force_menu);
+        }
+    }
+
+    /// Reset Button Down
+    pub fn reset_button_down() -> u32 {
+        unsafe { ogc_sys::SYS_ResetButtonDown() }
+    }
+
+    /// Set Reset Callback
+    pub fn set_reset_callback<F>(callback: Box<F>) {
+        unsafe {
+            // TODO: Check if this implementation can be changed.
+            let ptr = Box::into_raw(callback);
+            let code: extern "C" fn(irq: u32, ctx: *mut c_void) = mem::transmute(ptr);
+            // TODO: Do something with the returned callback.
+            let _ = ogc_sys::SYS_SetResetCallback(Some(code));
+        }
+    }
+
+    /// Set Power Callback
+    pub fn set_power_callback<F>(callback: Box<F>) {
+        unsafe {
+            // TODO: Check if this implementation can be changed.
+            let ptr = Box::into_raw(callback);
+            let code: extern "C" fn() = mem::transmute(ptr);
+            // TODO: Do something with the returned callback.
+            let _ = ogc_sys::SYS_SetPowerCallback(Some(code));
+        }
+    }
+
+    /// Protect Range
+    pub fn protect_range(
+        channel: MemoryProtectChannels,
+        address: u32,
+        bytes: u32,
+        control: MemoryProtectModes,
+    ) {
+        unsafe {
+            ogc_sys::SYS_ProtectRange(
+                channel.to_u32().unwrap(),
+                address as *mut c_void,
+                bytes,
+                control.to_u32().unwrap(),
+            );
+        }
+    }
+
+    /// Switch Fiber
+    pub fn switch_fiber(arg0: u32, arg1: u32, arg2: u32, arg3: u32, pc: u32, newsp: u32) {
+        unsafe {
+            ogc_sys::SYS_SwitchFiber(arg0, arg1, arg2, arg3, pc, newsp);
+        }
+    }
+
+    /// Get Hollywood Revision
+    pub fn get_hollywood_revision() -> u32 {
+        unsafe {
+            ogc_sys::SYS_GetHollywoodRevision()
+        }
+    }
+
     /// Get system time.
     pub fn system_time() -> u64 {
-        unsafe {
-            ogc_sys::SYS_Time()
-        }
+        unsafe { ogc_sys::SYS_Time() }
     }
 }

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -1,0 +1,19 @@
+//! The ``system`` module of ``ogc-rs``.
+//!
+//! This module implements a safe wrapper around the OS functions found in ``system.h``.
+
+use std::{mem, ptr};
+
+/// Represents the system service.
+/// The initialization of this service is done in the crt0 startup code.
+pub struct System(());
+
+/// Implementation of the system service.
+impl System {
+    /// Get system time.
+    pub fn system_time() -> u64 {
+        unsafe {
+            ogc_sys::SYS_Time()
+        }
+    }
+}

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -1,7 +1,5 @@
 //! Utility Functions to convert between types.
 
-use std::ffi::c_void;
-
 /// Converts a raw *mut u8 into a String.
 pub fn raw_to_string(raw: *mut u8) -> String {
     unsafe {
@@ -24,7 +22,82 @@ pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
     }
 }
 
-/// Converts uncached memory into cached memory (K0 type into K1 type).
-pub fn mem_k0_to_k1(x: *mut c_void) -> *mut c_void {
-    ((x as u32) + (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
+/// OS memory casting macros.
+mod memory_casting {
+    /// Cast a cached address to a uncached address.
+    /// Example: 0x8xxxxxxx -> 0xCxxxxxxx
+    #[macro_export]
+    macro_rules! mem_cached_to_uncached {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) + (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
+        }};
+    }
+
+    /// Cast a cached address to a physical address.
+    /// Example: 0x8xxxxxxx -> 0x0xxxxxxx
+    #[macro_export]
+    macro_rules! mem_cached_to_physical {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) - ogc_sys::SYS_BASE_CACHED) as *mut c_void
+        }};
+    }
+
+    /// Cast a uncached address to a cached address.
+    /// Example: 0xCxxxxxxx -> 0x8xxxxxxx
+    #[macro_export]
+    macro_rules! mem_uncached_to_cached {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) - (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
+        }};
+    }
+
+    /// Cast a uncached address to a physical address.
+    /// Example: 0x0xxxxxxx -> 0xCxxxxxxx
+    #[macro_export]
+    macro_rules! mem_uncached_to_physical {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) - ogc_sys::SYS_BASE_UNCACHED) as *mut c_void
+        }};
+    }
+
+    /// Cast a physical address to a cached address.
+    /// Example: 0x0xxxxxxx -> 0x8xxxxxxx
+    #[macro_export]
+    macro_rules! mem_physical_to_cached {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) + ogc_sys::SYS_BASE_CACHED) as *mut c_void
+        }};
+    }
+
+    /// Cast a physical address to a uncached address.
+    /// Example: 0x0xxxxxxx -> 0xCxxxxxxx
+    #[macro_export]
+    macro_rules! mem_physical_to_uncached {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) + ogc_sys::SYS_BASE_UNCACHED) as *mut c_void
+        }};
+    }
+
+    /// Cast a virtual address to a physical address.  
+    /// Example: 0x8xxxxxxx -> 0x0xxxxxxx
+    #[macro_export]
+    macro_rules! mem_virtual_to_physical {
+        ( $x:expr ) => {{
+            use std::ffi::c_void;
+
+            (($x as u32) & !ogc_sys::SYS_BASE_UNCACHED) as *mut c_void
+        }};
+    }
 }


### PR DESCRIPTION
This branch adds the ``system`` module to ``ogc-rs``

``system`` implements all functionality from ``system.h`` from libogc through ``ogc-sys``

``system`` also implements all OS memory casting macros in ``utils.rs``
All memory casting macros are named after the macros from ``system.h`` with 
- ``k0`` being replaced with ``cached`` 
- ``k1`` being replaced with ``uncached``