### PR TITLE
Add Video module to ogc-rs

### DIFF
--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -35,6 +35,9 @@ pub mod audio;
 /// Console Implementation
 pub mod console;
 
+/// Video Implementation
+pub mod video;
+
 /// Utility Functions
 pub mod utils;
 pub use utils::*;

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -16,7 +16,7 @@ struct render_config {
     v_filter: [u8; 7u32],
 }
 struct Video {
-    pub rmode: render_config,
+    pub render_config: render_config,
     pub framebuffer: std::ffi::c_void,
 }
 
@@ -29,9 +29,9 @@ impl Video {
         Video(())
     }
 
-    pub fn clear_framebuffer(rconf: render_config, framebuffer: std::ffi::c_void, colour: u32) -> () {
+    pub fn clear_framebuffer(&mut self, rconf: render_config, colour: u32) -> () {
         unsafe {
-            ogc_sys::VIDEO_ClearFrameBuffer(rconf, framebuffer, colour);
+            ogc_sys::VIDEO_ClearFrameBuffer(rconf, self.framebuffer, colour);
         }
     }
 

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -1,6 +1,6 @@
 use std::ffi;
 
-struct render_config {
+struct RenderConfig {
     tv_type: u32,
     framebuffer_width: u16,
     embed_framebuffer_height: u16,
@@ -15,7 +15,7 @@ struct render_config {
     sample_pattern: [[u8; 2u32]; 12u32],
     v_filter: [u8; 7u32],
 }
-struct Video {
+struct Video {  
     pub render_config: render_config,
     pub framebuffer: std::ffi::c_void,
 }

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -1,7 +1,11 @@
-use std::ffi;
-use system::System;
+//! The ``video`` module of ``ogc-rs``.
+//!
+//! This module implements a safe wrapper around video functions.
 
-struct RenderConfig {
+use crate::{mem_k0_to_k1, system::System, FromPrimitive, Primitive};
+use std::{ffi::c_void, mem, ptr};
+
+pub struct RenderConfig {
     tv_type: u32,
     framebuffer_width: u16,
     embed_framebuffer_height: u16,
@@ -13,26 +17,26 @@ struct RenderConfig {
     extern_framebuffer_mode: u32,
     field_rendering: u8,
     anti_aliasing: u8,
-    sample_pattern: [[u8; 2u32]; 12u32],
-    v_filter: [u8; 7u32],
+    sample_pattern: [[u8; 2usize]; 12usize],
+    v_filter: [u8; 7usize],
 }
 
-impl Into<*mut ogc_sys::GXRModeObj> for &mut RenderConfig {
+impl Into<*mut ogc_sys::GXRModeObj> for RenderConfig {
     fn into(self) -> *mut ogc_sys::GXRModeObj {
         Box::into_raw(Box::new(ogc_sys::GXRModeObj {
-            viTVMode:        self.tv_type,
-            fbWidth:         self.framebuffer_width,
-            efbHeight:       self.embed_framebuffer_height,
-            xfbHeight:       self.extern_framebuffer_height,
-            viXOrigin:       self.vi_x_origin,
-            viYOrigin:       self.vi_y_origin,
-            viWidth:         self.vi_width,
-            viHeight:        self.vi_height,
-            xfbMode:         self.extern_framebuffer_mode,
+            viTVMode: self.tv_type,
+            fbWidth: self.framebuffer_width,
+            efbHeight: self.embed_framebuffer_height,
+            xfbHeight: self.extern_framebuffer_height,
+            viXOrigin: self.vi_x_origin,
+            viYOrigin: self.vi_y_origin,
+            viWidth: self.vi_width,
+            viHeight: self.vi_height,
+            xfbMode: self.extern_framebuffer_mode,
             field_rendering: self.field_rendering,
-            aa:              self.anti_aliasing,
-            sample_pattern:  self.sample_pattern,
-            vfilter:         self.v_filter
+            aa: self.anti_aliasing,
+            sample_pattern: self.sample_pattern,
+            vfilter: self.v_filter,
         }))
     }
 }
@@ -40,123 +44,139 @@ impl Into<*mut ogc_sys::GXRModeObj> for &mut RenderConfig {
 impl Into<RenderConfig> for *mut ogc_sys::GXRModeObj {
     fn into(self) -> RenderConfig {
         RenderConfig {
-            tv_type: self.viTVMode,
-            framebuffer_width: self.fbWidth,
-            embed_framebuffer_height: self.efbHeight,
-            extern_framebuffer_height: self.xfbHeight,
-            vi_x_origin: self.viXOrigin,
-            vi_y_origin: self.viYOrigin,
-            vi_width: self.viWidth,
-            vi_height: self.viHeight,
-            extern_framebuffer_mode: self.xfbMode,
-            field_rendering: self.field_rendering,
-            anti_aliasing: self.aa,
-            sample_pattern: self.sample_pattern,
-            v_filter: self.vfilter
+            tv_type: (*self).viTVMode,
+            framebuffer_width: (*self).fbWidth,
+            embed_framebuffer_height: (*self).efbHeight,
+            extern_framebuffer_height: (*self).xfbHeight,
+            vi_x_origin: (*self).viXOrigin,
+            vi_y_origin: (*self).viYOrigin,
+            vi_width: (*self).viWidth,
+            vi_height: (*self).viHeight,
+            extern_framebuffer_mode: (*self).xfbMode,
+            field_rendering: (*self).field_rendering,
+            anti_aliasing: (*self).aa,
+            sample_pattern: (*self).sample_pattern,
+            v_filter: (*self).vfilter,
         }
     }
 }
 
-enum tv_mode {
-    vi_ntsc = 0, //Used in NA / JPN
-    vi_pal = 1, //Used in Europe
-    vi_mpal = 2, //Similar to NTSC, Used in Brazil
-    vi_debug = 3, //Debug Mode for NA / JPN - Special Decoder Needed
-    vi_debug_pal = 4, //Debug mode for EU - Special Decoder Needed
-    vi_eu_rgb_60 = 5 //RGB 60Hz, 480 lines (same timing + aspect as NTSC) used in Europe
+#[derive(Debug, Eq, PartialEq, Primitive)]
+pub enum TVMode {
+    /// Used in NA / JPN
+    ViNtsc = 0,
+    /// Used in Europe      
+    ViPal = 1,
+    /// Similar to NTSC, Used in Brazil       
+    ViMpal = 2,
+    /// Debug Mode for NA / JPN - Special Decoder Needed      
+    ViDebug = 3,
+    /// Debug mode for EU - Special Decoder Needed     
+    ViDebugPal = 4,
+    /// RGB 60Hz, 480 lines (same timing + aspect as NTSC) used in Europe
+    ViEuRgb60 = 5,
 }
 
-enum field {
-    vi_lower_field = 0,
-    vi_upper_field = 1
+#[derive(Debug, Eq, PartialEq, Primitive)]
+pub enum ViField {
+    ViLowerField = 0,
+    ViUpperField = 1,
 }
 
-struct Video {  
-    pub render_config: render_config,
-    pub framebuffer: std::ffi::c_void,
+/// Represents the video service.
+pub struct Video {
+    pub render_config: RenderConfig,
+    pub framebuffer: *mut c_void,
 }
 
 impl Video {
-
-    pub fn init() -> () {
+    pub fn init() -> Self {
         unsafe {
             ogc_sys::VIDEO_Init();
         }
 
-        Video(get_preferred_mode(), utils::cached_to_uncached!(System::allocate_framebuffer(get_preferred_mode())));
+        Video {
+            render_config: Self::get_preferred_mode(),
+            framebuffer: mem_k0_to_k1(System::allocate_framebuffer(Self::get_preferred_mode())),
+        }
     }
 
-    pub fn clear_framebuffer(&mut self, rconf: render_config, colour: u32) -> () {
+    pub fn clear_framebuffer(&mut self, rconf: RenderConfig, colour: u32) {
         unsafe {
-            ogc_sys::VIDEO_ClearFrameBuffer(rconf, self.framebuffer, colour);
+            ogc_sys::VIDEO_ClearFrameBuffer(rconf.into(), self.framebuffer, colour);
         }
     }
 
     pub fn get_preferred_mode() -> RenderConfig {
-        unsafe {
-            ogc_sys::VIDEO_GetPreferredMode(std::ptr::null_mut()).into()
-        }
+        unsafe { ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()).into() }
     }
 
-    pub fn configure(render_config: RenderConfig) -> () {
+    pub fn configure(render_config: RenderConfig) {
         unsafe {
             ogc_sys::VIDEO_Configure(render_config.into());
         }
     }
 
-    pub fn flush() -> () {
+    pub fn flush() {
         unsafe {
             ogc_sys::VIDEO_Flush();
         }
     }
 
-    pub fn get_current_line() -> () {
+    pub fn get_current_line() {
         unsafe {
             ogc_sys::VIDEO_GetCurrentLine();
         }
     }
 
-    pub fn get_tv_mode() -> tv_mode {
+    pub fn get_tv_mode() -> TVMode {
         unsafe {
             let mode = ogc_sys::VIDEO_GetCurrentTvMode();
+            TVMode::from_u32(mode).unwrap()
         }
-        tv_mode::from_u32(mode).unwrap();
     }
 
-    pub fn get_next_field() -> field {
+    pub fn get_next_field() -> ViField {
         unsafe {
             let next_field = ogc_sys::VIDEO_GetNextField();
+            ViField::from_u32(next_field).unwrap()
         }
-        field::from_u32(next_field).unwrap();
     }
 
     pub fn is_component_cable() -> bool {
         unsafe {
             let component = ogc_sys::VIDEO_HaveComponentCable();
-        }
 
-        bool::from_u32(component).unwrap();
+            if component == 1 {
+                true
+            } else {
+                false
+            }
+        }
     }
 
-    pub fn set_black(is_black: bool) -> () {
+    pub fn set_black(is_black: bool) {
         unsafe {
             ogc_sys::VIDEO_SetBlack(is_black);
         }
     }
 
-    pub fn set_next_framebuffer(framebuffer: *mut std::ffi::c_void) -> () {
+    pub fn set_next_framebuffer(framebuffer: *mut c_void) {
         unsafe {
             ogc_sys::VIDEO_SetNextFramebuffer(framebuffer);
         }
     }
 
-    pub fn set_next_right_framebuffer(framebuffer: *mut std::ffi::c_void) -> () {
+    pub fn set_next_right_framebuffer(framebuffer: *mut c_void) {
         unsafe {
             ogc_sys::VIDEO_SetNextRightFramebuffer(framebuffer);
         }
     }
 
-    pub fn register_post_retrace_callback<F>(callback: Box<F>) where F: Fn(u32) -> (), {
+    pub fn register_post_retrace_callback<F>(callback: Box<F>)
+    where
+        F: Fn(u32) -> (),
+    {
         unsafe {
             let ptr = Box::into_raw(callback);
             let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
@@ -165,7 +185,10 @@ impl Video {
         }
     }
 
-    pub fn register_pre_retrace_callback<F>(callback: Box<F>) where F: Fn(u32) -> (), {
+    pub fn register_pre_retrace_callback<F>(callback: Box<F>)
+    where
+        F: Fn(u32) -> (),
+    {
         unsafe {
             let ptr = Box::into_raw(callback);
             let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
@@ -174,10 +197,9 @@ impl Video {
         }
     }
 
-    pub fn wait_vsync() -> () {
+    pub fn wait_vsync() {
         unsafe {
             ogc_sys::VIDEO_WaitVSync();
         }
     }
-
 }

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -1,4 +1,5 @@
 use std::ffi;
+use system::System;
 
 struct RenderConfig {
     tv_type: u32,
@@ -15,18 +16,74 @@ struct RenderConfig {
     sample_pattern: [[u8; 2u32]; 12u32],
     v_filter: [u8; 7u32],
 }
+
+impl Into<*mut ogc_sys::GXRModeObj> for &mut RenderConfig {
+    fn into(self) -> *mut ogc_sys::GXRModeObj {
+        Box::into_raw(Box::new(ogc_sys::GXRModeObj {
+            viTVMode:        self.tv_type,
+            fbWidth:         self.framebuffer_width,
+            efbHeight:       self.embed_framebuffer_height,
+            xfbHeight:       self.extern_framebuffer_height,
+            viXOrigin:       self.vi_x_origin,
+            viYOrigin:       self.vi_y_origin,
+            viWidth:         self.vi_width,
+            viHeight:        self.vi_height,
+            xfbMode:         self.extern_framebuffer_mode,
+            field_rendering: self.field_rendering,
+            aa:              self.anti_aliasing,
+            sample_pattern:  self.sample_pattern,
+            vfilter:         self.v_filter
+        }))
+    }
+}
+
+impl Into<RenderConfig> for *mut ogc_sys::GXRModeObj {
+    fn into(self) -> RenderConfig {
+        RenderConfig {
+            tv_type: self.viTVMode,
+            framebuffer_width: self.fbWidth,
+            embed_framebuffer_height: self.efbHeight,
+            extern_framebuffer_height: self.xfbHeight,
+            vi_x_origin: self.viXOrigin,
+            vi_y_origin: self.viYOrigin,
+            vi_width: self.viWidth,
+            vi_height: self.viHeight,
+            extern_framebuffer_mode: self.xfbMode,
+            field_rendering: self.field_rendering,
+            anti_aliasing: self.aa,
+            sample_pattern: self.sample_pattern,
+            v_filter: self.vfilter
+        }
+    }
+}
+
+enum tv_mode {
+    vi_ntsc = 0, //Used in NA / JPN
+    vi_pal = 1, //Used in Europe
+    vi_mpal = 2, //Similar to NTSC, Used in Brazil
+    vi_debug = 3, //Debug Mode for NA / JPN - Special Decoder Needed
+    vi_debug_pal = 4, //Debug mode for EU - Special Decoder Needed
+    vi_eu_rgb_60 = 5 //RGB 60Hz, 480 lines (same timing + aspect as NTSC) used in Europe
+}
+
+enum field {
+    vi_lower_field = 0,
+    vi_upper_field = 1
+}
+
 struct Video {  
     pub render_config: render_config,
     pub framebuffer: std::ffi::c_void,
 }
 
 impl Video {
+
     pub fn init() -> () {
         unsafe {
             ogc_sys::VIDEO_Init();
         }
 
-        Video(())
+        Video(get_preferred_mode(), utils::cached_to_uncached!(System::allocate_framebuffer(get_preferred_mode())));
     }
 
     pub fn clear_framebuffer(&mut self, rconf: render_config, colour: u32) -> () {
@@ -35,5 +92,92 @@ impl Video {
         }
     }
 
-    
+    pub fn get_preferred_mode() -> RenderConfig {
+        unsafe {
+            ogc_sys::VIDEO_GetPreferredMode(std::ptr::null_mut()).into()
+        }
+    }
+
+    pub fn configure(render_config: RenderConfig) -> () {
+        unsafe {
+            ogc_sys::VIDEO_Configure(render_config.into());
+        }
+    }
+
+    pub fn flush() -> () {
+        unsafe {
+            ogc_sys::VIDEO_Flush();
+        }
+    }
+
+    pub fn get_current_line() -> () {
+        unsafe {
+            ogc_sys::VIDEO_GetCurrentLine();
+        }
+    }
+
+    pub fn get_tv_mode() -> tv_mode {
+        unsafe {
+            let mode = ogc_sys::VIDEO_GetCurrentTvMode();
+        }
+        tv_mode::from_u32(mode).unwrap();
+    }
+
+    pub fn get_next_field() -> field {
+        unsafe {
+            let next_field = ogc_sys::VIDEO_GetNextField();
+        }
+        field::from_u32(next_field).unwrap();
+    }
+
+    pub fn is_component_cable() -> bool {
+        unsafe {
+            let component = ogc_sys::VIDEO_HaveComponentCable();
+        }
+
+        bool::from_u32(component).unwrap();
+    }
+
+    pub fn set_black(is_black: bool) -> () {
+        unsafe {
+            ogc_sys::VIDEO_SetBlack(is_black);
+        }
+    }
+
+    pub fn set_next_framebuffer(framebuffer: *mut std::ffi::c_void) -> () {
+        unsafe {
+            ogc_sys::VIDEO_SetNextFramebuffer(framebuffer);
+        }
+    }
+
+    pub fn set_next_right_framebuffer(framebuffer: *mut std::ffi::c_void) -> () {
+        unsafe {
+            ogc_sys::VIDEO_SetNextRightFramebuffer(framebuffer);
+        }
+    }
+
+    pub fn register_post_retrace_callback<F>(callback: Box<F>) where F: Fn(u32) -> (), {
+        unsafe {
+            let ptr = Box::into_raw(callback);
+            let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
+
+            let _ = ogc_sys::VIDEO_SetPostRetraceCallback(Some(code));
+        }
+    }
+
+    pub fn register_pre_retrace_callback<F>(callback: Box<F>) where F: Fn(u32) -> (), {
+        unsafe {
+            let ptr = Box::into_raw(callback);
+            let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
+
+            let _ = ogc_sys::VIDEO_SetPreRetraceCallback(Some(code));
+        }
+    }
+
+    pub fn wait_vsync() -> () {
+        unsafe {
+            ogc_sys::VIDEO_WaitVSync();
+        }
+    }
+
 }

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -1,0 +1,39 @@
+use std::ffi;
+
+struct render_config {
+    tv_type: u32,
+    framebuffer_width: u16,
+    embed_framebuffer_height: u16,
+    extern_framebuffer_height: u16,
+    vi_x_origin: u16,
+    vi_y_origin: u16,
+    vi_width: u16,
+    vi_height: u16,
+    extern_framebuffer_mode: u32,
+    field_rendering: u8,
+    anti_aliasing: u8,
+    sample_pattern: [[u8; 2u32]; 12u32],
+    v_filter: [u8; 7u32],
+}
+struct Video {
+    pub rmode: render_config,
+    pub framebuffer: std::ffi::c_void,
+}
+
+impl Video {
+    pub fn init() -> () {
+        unsafe {
+            ogc_sys::VIDEO_Init();
+        }
+
+        Video(())
+    }
+
+    pub fn clear_framebuffer(rconf: render_config, framebuffer: std::ffi::c_void, colour: u32) -> () {
+        unsafe {
+            ogc_sys::VIDEO_ClearFrameBuffer(rconf, framebuffer, colour);
+        }
+    }
+
+    
+}


### PR DESCRIPTION
This pull from the video branch adds the `video` module to `ogc-rs`

Console implements all functionality from `video.h` from `libogc` through `ogc-sys`
This includes:

- `VIDEO_Init` [`Console::init`] (Initializes the video module)
- `VIDEO_ClearFrameBuffer` [`Video::clear_framebuffer`] (Clears the given framebuffer with a given config and colour)
- `VIDEO_GetPreferredMode` [`Video::get_preferred_mode`] (Get the preferred video settings based on current display)
- `VIDEO_Configure` [`Video::configure`] (Configure the Video Interface with the given RenderConfig object)
- `VIDEO_Flush` [`Video::flush`] (Flush the shadow registers to the drivers video registers)
- `VIDEO_GetCurrentLine` [`Video::get_current_line`] (Get the current line number)
- `VIDEO_GetCurrentTvMode` [`Video::get_tv_mode`] (Get the current RenderConfig)
- `VIDEO_GetNextField` [`Video::get_next_field`] (Return the next field (upper or lower) )
- `VIDEO_HaveComponentCable` [`Video::is_component_cable`] (Returns a bool based on if a YPbPr component cable is being used)
- `VIDEO_SetBlack` [`Video::set_black`] (Set the display to black or not black using a bool)
- `VIDEO_SetNextFramebuffer` [`Video::set_next_framebuffer`] (Set the framebuffer for the next VI Register update)
- `VIDEO_WaitVSync` [`Video::wait_vsync`] (Wait on the next vertical retrace)

This branch also adds the structures:
- `RenderConfig` (A struct to hold rendering configurations)
- `Video` (Holds a framebuffer and a RenderConfig, all functions are impl'd on it)
- `tv_mode` (The current TV mode [PAL, NTSC, etc.])
- `field` (The upper or lower field, returned by GetNextField)

This branch also has Impl's for Into on GXRModeObj and RenderConfig, to allow converting between the 2 for function calls in C or Rust