### PR TITLE
Convert ogc-rs to no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,27 +11,16 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "enum_primitive"
+version = "0.1.1"
 dependencies = [
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
 version = "0.2.56"
 source = "git+https://github.com/rust-wii/libc.git?branch=wii#172289d8db97f950f22b4d42598f056e70759a18"
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num-traits"
@@ -43,57 +32,23 @@ dependencies = [
 
 [[package]]
 name = "ogc-rs"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_primitive 0.1.1",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ogc-sys 0.2.0",
+ "ogc-sys 0.3.0",
 ]
 
 [[package]]
 name = "ogc-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libc 0.2.56 (git+https://github.com/rust-wii/libc.git?branch=wii)",
 ]
 
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [metadata]
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
-"checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
 "checksum libc 0.2.56 (git+https://github.com/rust-wii/libc.git?branch=wii)" = "<none>"
-"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "enum_primitive"
 version = "0.1.1"
+source = "git+https://github.com/FrictionlessPortals/enum_primitive-rs.git#a069484e4292ab5b9e5fe899368f5b7b2903e454"
 dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -32,11 +33,10 @@ dependencies = [
 
 [[package]]
 name = "ogc-rs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum_primitive 0.1.1",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_primitive 0.1.1 (git+https://github.com/FrictionlessPortals/enum_primitive-rs.git)",
  "ogc-sys 0.3.0",
 ]
 
@@ -50,5 +50,6 @@ dependencies = [
 [metadata]
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum enum_primitive 0.1.1 (git+https://github.com/FrictionlessPortals/enum_primitive-rs.git)" = "<none>"
 "checksum libc 0.2.56 (git+https://github.com/rust-wii/libc.git?branch=wii)" = "<none>"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"

--- a/ogc-rs/Cargo.toml
+++ b/ogc-rs/Cargo.toml
@@ -10,8 +10,10 @@ name = "ogc"
 
 [dependencies]
 bitflags = "1.1"
-enum-primitive-derive = "0.1"
-num-traits = "0.2"
+
+[dependencies.enum_primitive]
+version = "0.1"
+git = "https://github.com/FrictionlessPortals/enum_primitive-rs.git"
 
 [dependencies.ogc-sys]
 path = "../ogc-sys"

--- a/ogc-rs/Cargo.toml
+++ b/ogc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogc-rs"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["rust-wii"]
 edition = "2018"
 

--- a/ogc-rs/README.md
+++ b/ogc-rs/README.md
@@ -7,6 +7,7 @@
 * ``network``: Provides TCP networking for the Wii.
 * ``audio``: Provides functions for audio on the Wii.
 * ``fs``: Provides functions for manipulating the filesystem on the Wii.
+* ``system``: Provides OS functions for the Wii.
 * ``console``: Provides console functions for the Wii.
 * ``input``: Provides an interface for reading input from devices on the Wii.
 * ``video``: Provides functions for video output on the Wii.

--- a/ogc-rs/README.md
+++ b/ogc-rs/README.md
@@ -7,12 +7,9 @@
 * ``network``: Provides TCP networking for the Wii.
 * ``audio``: Provides functions for audio on the Wii.
 * ``fs``: Provides functions for manipulating the filesystem on the Wii.
-* ``system``: Provides OS functions for the Wii.
 * ``console``: Provides console functions for the Wii.
 * ``input``: Provides an interface for reading input from devices on the Wii.
 * ``video``: Provides functions for video output on the Wii.
 * ``gx``: Provides an opengl-like interface for rendering on the Wii.
 
-Features such as ``network``, ``fs`` and ``console`` have been merged into ``std`` to extend functionality.
-
-However it is still possible to use these features if you require certain functionality missing from ``std``.
+``ogc-rs`` also provides runtime functions and an allocator for ``no_std`` environments.

--- a/ogc-rs/src/audio.rs
+++ b/ogc-rs/src/audio.rs
@@ -2,38 +2,43 @@
 //!
 //! This module implements a safe wrapper around the audio functions found in ``audio.h``.
 
-use crate::{FromPrimitive, Primitive, ToPrimitive};
-use std::{mem, ptr};
+use alloc::boxed::Box;
+use core::{mem, ptr};
+use enum_primitive::*;
 
 /// Represents the audio service.
 /// No audio control can be done until an instance of this struct is created.
 /// This service can only be created once!
-pub struct Audio(());
+pub struct Audio;
 
-/// The play state of the ``audio`` service.
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum PlayState {
-    Started = 1,
-    Stopped = 0,
+enum_primitive! {
+    /// The play state of the ``audio`` service.
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum PlayState {
+        Started = 1,
+        Stopped = 0,
+    }
 }
 
-/// The sample rate of the ``audio`` service.
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum SampleRate {
-    FortyEightKhz = 1,
-    ThirtySixKhz = 0,
+enum_primitive! {
+    /// The sample rate of the ``audio`` service.
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum SampleRate {
+        FortyEightKhz = 1,
+        ThirtySixKhz = 0,
+    }
 }
 
 /// Implementation of the audio service.
 impl Audio {
     /// Initialization of the audio service.
-    pub fn init() -> Audio {
+    pub fn init() -> Self {
         unsafe {
             // For now this is a mutable null pointer.
             // libogc is fine with this, but this should be changed in the future.
             ogc_sys::AUDIO_Init(ptr::null_mut());
 
-            Audio(())
+            Self
         }
     }
 

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -2,18 +2,19 @@
 //!
 //! This module implements a safe wrapper around the console functions.
 
-use crate::{mem_cached_to_uncached, video::Video, OgcError, Result};
-use std::ptr;
+use crate::{video::Video, OgcError, Result};
+use alloc::string::String;
+use core::ptr;
 
 /// Represents the console service.
 /// No console control can be done until an instance of this struct is created.
 /// This service can only be created once!
-pub struct Console(());
+pub struct Console;
 
 /// Implementation of the console service.
 impl Console {
     /// Initializes the console subsystem with video.
-    pub fn init(video: &Video) -> Console {
+    pub fn init(video: &Video) -> Self {
         unsafe {
             ogc_sys::CON_Init(
                 video.framebuffer,
@@ -25,7 +26,7 @@ impl Console {
             );
         }
 
-        Console(())
+        Self
     }
 
     /// Initialize stdout console.

--- a/ogc-rs/src/debug.rs
+++ b/ogc-rs/src/debug.rs
@@ -2,13 +2,15 @@
 //!
 //! This module implements a safe wrapper around the debug functions.
 
-use crate::{Primitive, ToPrimitive};
+use enum_primitive::*;
 
-/// Enum for gdb stub types.
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum GDBStubDevice {
-    Usb = 0,
-    Tcp = 1,
+enum_primitive! {
+    /// Enum for gdb stub types.
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum GDBStubDevice {
+        Usb = 0,
+        Tcp = 1,
+    }
 }
 
 /// Performs the initialization of the debug stub.
@@ -18,8 +20,8 @@ pub fn debug_init(device_type: GDBStubDevice, channel_port: i32) {
     }
 }
 
-/// Stub function to insert the hardware break instruction. 
-/// This function is used to enter the debug stub and to connect with the host. 
+/// Stub function to insert the hardware break instruction.
+/// This function is used to enter the debug stub and to connect with the host.
 /// The developer is free to insert this function at any position in project's source code.
 pub fn insert_break() {
     unsafe {

--- a/ogc-rs/src/error.rs
+++ b/ogc-rs/src/error.rs
@@ -1,9 +1,10 @@
 //! Custom Error Implementation for ``ogc-rs``.
 
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 /// Custom Result Type that uses the error type.
-pub type Result<T> = std::result::Result<T, OgcError>;
+pub type Result<T> = core::result::Result<T, OgcError>;
 
 /// Custom Error Type
 pub enum OgcError {

--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -7,6 +7,7 @@
 //! * ``network``: Provides TCP networking for the Wii.
 //! * ``audio``: Provides functions for audio on the Wii.
 //! * ``fs``: Provides functions for manipulating the filesystem on the Wii.
+//! * ``system``: Provides OS functions for the Wii.
 //! * ``console``: Provides console functions for the Wii.
 //! * ``input``: Provides an interface for reading input from devices on the Wii.
 //! * ``video``: Provides functions for video output on the Wii.

--- a/ogc-rs/src/lib.rs
+++ b/ogc-rs/src/lib.rs
@@ -12,15 +12,16 @@
 //! * ``video``: Provides functions for video output on the Wii.
 //! * ``gx``: Provides an opengl-like interface for rendering on the Wii.
 //!
-//! Features such as ``network``, ``fs`` and ``console`` have been merged into ``std`` to extend functionality.
-//! However it is still possible to use these features if you require certain functionality missing from ``std``.
+//! ``ogc-rs`` also provides runtime functions and an allocator for ``no_std``
+//! environments.
 
-#![crate_type = "rlib"]
-#![crate_name = "ogc"]
+#![no_std]
+#![allow(dead_code)]
+#![feature(panic_info_message)]
+#![feature(alloc_error_handler)]
 
+extern crate alloc;
 use bitflags::bitflags;
-use enum_primitive_derive::Primitive;
-use num_traits::cast::{FromPrimitive, ToPrimitive};
 
 // Custom Error Implementation
 pub mod error;
@@ -43,8 +44,31 @@ pub mod video;
 
 /// Debugging Functions
 pub mod debug;
-pub use debug::*;
 
-/// Utility Functions
+// Utility Functions
 pub mod utils;
 pub use utils::*;
+
+// Runtime Functions
+pub mod runtime;
+
+/// Prelude
+pub mod prelude {
+    // alloc Export
+    pub use alloc::boxed::Box;
+    pub use alloc::string::{String, ToString};
+    pub use alloc::{vec, vec::Vec};
+
+    // Export Services
+    pub use crate::console::*;
+    pub use crate::debug::*;
+    pub use crate::system::*;
+    pub use crate::video::*;
+    pub use crate::{print, println};
+
+    // Global Allocator
+    use crate::runtime::OGCAllocator;
+
+    #[global_allocator]
+    static GLOBAL_ALLOCATOR: OGCAllocator = OGCAllocator;
+}

--- a/ogc-rs/src/network.rs
+++ b/ogc-rs/src/network.rs
@@ -2,8 +2,15 @@
 //!
 //! This module implements a safe wrapper around the networking functions found in ``network.h``.
 
-use crate::{bitflags, raw_to_string, raw_to_strings, OgcError, Primitive, Result, ToPrimitive};
-use std::{ffi::c_void, ptr};
+use crate::{bitflags, raw_to_string, raw_to_strings, OgcError, Result};
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{ffi::c_void, ptr};
+use enum_primitive::*;
 
 bitflags! {
     /// Optional flags for sockets.
@@ -94,19 +101,23 @@ bitflags! {
     }
 }
 
-/// Protocol Families
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum ProtocolFamily {
-    AfUnspec = 0,
-    AfInet = 2,
+enum_primitive! {
+    /// Protocol Families
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum ProtocolFamily {
+        AfUnspec = 0,
+        AfInet = 2,
+    }
 }
 
-/// Socket Types
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum SocketType {
-    SockStream = 1,
-    SockDgram = 2,
-    SockRaw = 3,
+enum_primitive! {
+    /// Socket Types
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum SocketType {
+        SockStream = 1,
+        SockDgram = 2,
+        SockRaw = 3,
+    }
 }
 
 /// Non Blocking IO
@@ -277,19 +288,19 @@ pub fn get_host_by_name(addr_string: &str) -> Result<HostInformation> {
 /// This service can only be created once!
 ///
 /// The service exits when all instances of this struct go out of scope.
-pub struct Network(());
+pub struct Network;
 
 /// Implementation of the networking service.
 impl Network {
     /// Initialization of the networking service.
-    pub fn init() -> Result<Network> {
+    pub fn init() -> Result<Self> {
         unsafe {
             let r = ogc_sys::net_init();
 
             if r < 0 {
                 Err(OgcError::Network(format!("network init: {}", r)))
             } else {
-                Ok(Network(()))
+                Ok(Self)
             }
         }
     }

--- a/ogc-rs/src/runtime.rs
+++ b/ogc-rs/src/runtime.rs
@@ -1,0 +1,68 @@
+//! The ``runtime`` module of ``ogc-rs``.
+//!
+//! This module implements runtime functions and allocators
+//! required for ``no_std`` on the Wii.
+//!
+//! Most of the functions defined here are modified functions from
+//! the helpful project [water](https://github.com/lemarcuspoilus/water).
+
+use crate::{print, println};
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    panic::PanicInfo,
+};
+
+/// Uses the system's memory allocation and de-allocation functions.
+///
+/// # Remarks
+/// This allocator _will panic_ if more than 16MB of memory is being allocated.
+/// Since the Wii has approximately 84MB of total memory, such an allocation is probably an error.
+pub struct OGCAllocator;
+
+unsafe impl GlobalAlloc for OGCAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() > 1024 * 1024 * 16 {
+            panic!(
+                "Attempted to allocate >16MB (asked for {} bytes)",
+                layout.size()
+            );
+        } else {
+            ogc_sys::malloc(layout.size() as u32) as *mut u8
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        ogc_sys::free(ptr as *mut _);
+    }
+}
+
+/// Panic Handler for the Wii.
+///
+/// **Note**: The panic handler uses the ``println`` macro for output.
+/// In order for this to work ``Console`` and a minimal ``Video`` setup is required!
+#[panic_handler]
+fn panic_handler(panic_info: &PanicInfo) -> ! {
+    println!("#######################################");
+    println!("# <[ PANIC ]> {} ", panic_info);
+    println!("#######################################");
+
+    loop {}
+}
+
+/// Allocation Error Handler for the Wii.
+///
+/// **Note**: The allocation error handler uses the ``println`` macro for output.
+/// In order for this to work ``Console`` and a minimal ``Video`` setup is required!
+#[alloc_error_handler]
+fn alloc_error(layout: Layout) -> ! {
+    println!("#######################################");
+    println!("# <[ ALLOC ]> Allocation Error!");
+    println!(
+        "# <[ ALLOC ]> Size: {} - Alignment: {}",
+        layout.size(),
+        layout.align()
+    );
+    println!("#######################################");
+
+    loop {}
+}

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -2,44 +2,52 @@
 //!
 //! This module implements a safe wrapper around the OS functions found in ``system.h``.
 
-use crate::{video::RenderConfig, OgcError, Primitive, Result, ToPrimitive};
-use std::ffi::c_void;
-use std::mem;
-use std::time::Duration;
+use crate::{video::RenderConfig, OgcError, Result};
+use alloc::boxed::Box;
+use core::ffi::c_void;
+use core::mem;
+use core::time::Duration;
+use enum_primitive::*;
 
 /// Represents the system service.
 /// The initialization of this service is done in the crt0 startup code.
-pub struct System(());
+pub struct System;
 
-/// OS Reset Types
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum ResetTypes {
-    Restart = 0,
-    HotReset = 1,
-    Shutdown = 2,
-    ReturnToMenu = 3,
-    PowerOff = 4,
-    PowerOffStandby = 5,
-    PowerOffIdle = 6,
+enum_primitive! {
+    /// OS Reset Types
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum ResetTypes {
+        Restart = 0,
+        HotReset = 1,
+        Shutdown = 2,
+        ReturnToMenu = 3,
+        PowerOff = 4,
+        PowerOffStandby = 5,
+        PowerOffIdle = 6,
+    }
 }
 
-/// OS Memory Protection Modes
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum MemoryProtectModes {
-    ProtectNone = 0,
-    ProtectRead = 1,
-    ProtectWrite = 2,
-    ProtectReadWrite = 1 | 2,
+enum_primitive! {
+    /// OS Memory Protection Modes
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum MemoryProtectModes {
+        ProtectNone = 0,
+        ProtectRead = 1,
+        ProtectWrite = 2,
+        ProtectReadWrite = 1 | 2,
+    }
 }
 
-/// OS Memory Protection Channels
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum MemoryProtectChannels {
-    ChannelZero = 0,
-    ChannelOne = 1,
-    ChannelTwo = 2,
-    ChannelThree = 3,
-    All = 4,
+enum_primitive! {
+    /// OS Memory Protection Channels
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum MemoryProtectChannels {
+        ChannelZero = 0,
+        ChannelOne = 1,
+        ChannelTwo = 2,
+        ChannelThree = 3,
+        All = 4,
+    }
 }
 
 /// System Font Header Structure

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -1,9 +1,12 @@
 //! Utility Functions to convert between types.
 
+use alloc::{string::String, vec::Vec};
+use core::slice;
+
 /// Converts a raw *mut u8 into a String.
 pub fn raw_to_string(raw: *mut u8) -> String {
     unsafe {
-        let slice = std::slice::from_raw_parts(raw, 1);
+        let slice = slice::from_raw_parts(raw, 1);
         String::from_utf8(slice.to_vec()).unwrap()
     }
 }
@@ -11,11 +14,11 @@ pub fn raw_to_string(raw: *mut u8) -> String {
 /// Converts a raw *mut *mut u8 into a String vector.
 pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
     unsafe {
-        let slice = std::slice::from_raw_parts(raw, 2);
+        let slice = slice::from_raw_parts(raw, 2);
         slice
-            .into_iter()
+            .iter()
             .map(|x: &*mut u8| {
-                let r = std::slice::from_raw_parts(*x, 1);
+                let r = slice::from_raw_parts(*x, 1);
                 String::from_utf8(r.to_vec()).unwrap()
             })
             .collect()
@@ -29,7 +32,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_cached_to_uncached {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) + (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
         }};
@@ -40,7 +43,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_cached_to_physical {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) - ogc_sys::SYS_BASE_CACHED) as *mut c_void
         }};
@@ -51,7 +54,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_uncached_to_cached {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) - (ogc_sys::SYS_BASE_UNCACHED - ogc_sys::SYS_BASE_CACHED)) as *mut c_void
         }};
@@ -62,7 +65,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_uncached_to_physical {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) - ogc_sys::SYS_BASE_UNCACHED) as *mut c_void
         }};
@@ -73,7 +76,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_physical_to_cached {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) + ogc_sys::SYS_BASE_CACHED) as *mut c_void
         }};
@@ -84,7 +87,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_physical_to_uncached {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) + ogc_sys::SYS_BASE_UNCACHED) as *mut c_void
         }};
@@ -95,7 +98,7 @@ mod memory_casting {
     #[macro_export]
     macro_rules! mem_virtual_to_physical {
         ( $x:expr ) => {{
-            use std::ffi::c_void;
+            use core::ffi::c_void;
 
             (($x as u32) & !ogc_sys::SYS_BASE_UNCACHED) as *mut c_void
         }};
@@ -111,8 +114,8 @@ mod console_printing {
     #[macro_export]
     macro_rules! print {
         ($($arg:tt)*) => {
-            let s = ::std::fmt::format(format_args!($($arg)*));
-            Console::print(&s);
+            let s = ::alloc::fmt::format(format_args!($($arg)*));
+            $crate::console::Console::print(&s);
         }
     }
 

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -2,8 +2,10 @@
 //!
 //! This module implements a safe wrapper around video functions.
 
-use crate::{mem_cached_to_uncached, system::System, FromPrimitive, Primitive};
-use std::{ffi::c_void, mem, ptr};
+use crate::{mem_cached_to_uncached, system::System};
+use alloc::boxed::Box;
+use core::{ffi::c_void, mem, ptr};
+use enum_primitive::*;
 
 pub struct RenderConfig {
     pub tv_type: u32,
@@ -65,26 +67,30 @@ impl Into<RenderConfig> for *mut ogc_sys::GXRModeObj {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum TVMode {
-    /// Used in NA / JPN
-    ViNtsc = 0,
-    /// Used in Europe      
-    ViPal = 1,
-    /// Similar to NTSC, Used in Brazil       
-    ViMpal = 2,
-    /// Debug Mode for NA / JPN - Special Decoder Needed      
-    ViDebug = 3,
-    /// Debug mode for EU - Special Decoder Needed     
-    ViDebugPal = 4,
-    /// RGB 60Hz, 480 lines (same timing + aspect as NTSC) used in Europe
-    ViEuRgb60 = 5,
+enum_primitive! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum TVMode {
+        /// Used in NA / JPN
+        ViNtsc = 0,
+        /// Used in Europe
+        ViPal = 1,
+        /// Similar to NTSC, Used in Brazil
+        ViMpal = 2,
+        /// Debug Mode for NA / JPN - Special Decoder Needed
+        ViDebug = 3,
+        /// Debug mode for EU - Special Decoder Needed
+        ViDebugPal = 4,
+        /// RGB 60Hz, 480 lines (same timing + aspect as NTSC) used in Europe
+        ViEuRgb60 = 5,
+    }
 }
 
-#[derive(Debug, Eq, PartialEq, Primitive)]
-pub enum ViField {
-    ViLowerField = 0,
-    ViUpperField = 1,
+enum_primitive! {
+    #[derive(Debug, Eq, PartialEq)]
+    pub enum ViField {
+        ViLowerField = 0,
+        ViUpperField = 1,
+    }
 }
 
 /// Represents the video service.
@@ -97,12 +103,10 @@ impl Video {
     pub fn init() -> Self {
         unsafe {
             ogc_sys::VIDEO_Init();
-        }
 
-        unsafe {
             let r_mode = ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()).into();
 
-            Video {
+            Self {
                 render_config: r_mode,
                 framebuffer: mem_cached_to_uncached!(System::allocate_framebuffer(
                     Self::get_preferred_mode().into()


### PR DESCRIPTION
This PR converts the ``ogc-rs`` crate to use ``core`` and ``alloc`` instead of ``std``.

This means ``ogc-rs`` can now be compiled without a custom libstd removing the chances of compilation breaking with unstable updates or major changes.

This update also adds runtime functions in ``runtime.rs`` which satisfies the compiler when compiling in a ``no_std`` environment. 

This also changes how much memory can be allocated to the Wii's maximum onboard RAM through the custom allocator and introduces a custom panic handler which outputs panic messages to the screen through ``println!``.

A small prelude section has also been added to the library to reduce the ``use`` statements.