### PR TITLE
Less code in unsafe and a logic error fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,52 +4,49 @@
 name = "autocfg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "enum_primitive"
 version = "0.1.1"
 source = "git+https://github.com/FrictionlessPortals/enum_primitive-rs.git#a069484e4292ab5b9e5fe899368f5b7b2903e454"
 dependencies = [
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits",
 ]
 
 [[package]]
 name = "libc"
 version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
 ]
 
 [[package]]
 name = "ogc-rs"
 version = "0.7.1"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum_primitive 0.1.1 (git+https://github.com/FrictionlessPortals/enum_primitive-rs.git)",
- "ogc-sys 0.4.0",
+ "bitflags",
+ "enum_primitive",
+ "ogc-sys",
 ]
 
 [[package]]
 name = "ogc-sys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
-
-[metadata]
-"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum enum_primitive 0.1.1 (git+https://github.com/FrictionlessPortals/enum_primitive-rs.git)" = "<none>"
-"checksum libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)" = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
-"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"

--- a/ogc-rs/src/audio.rs
+++ b/ogc-rs/src/audio.rs
@@ -79,9 +79,10 @@ impl Audio {
     where
         F: Fn(u32) -> (),
     {
+        // TODO: Check if this implementation can be changed.
+        let ptr = Box::into_raw(callback);
+        
         unsafe {
-            // TODO: Check if this implementation can be changed.
-            let ptr = Box::into_raw(callback);
             let code: extern "C" fn(smp_cnt: u32) = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
             let _ = ogc_sys::AUDIO_RegisterStreamCallback(Some(code));
@@ -96,9 +97,10 @@ impl Audio {
     where
         F: Fn() -> (),
     {
+        // TODO: Check if this implementation can be changed.
+        let ptr = Box::into_raw(callback);
+        
         unsafe {
-            // TODO: Check if this implementation can be changed.
-            let ptr = Box::into_raw(callback);
             let code: extern "C" fn() = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
             let _ = ogc_sys::AUDIO_RegisterDMACallback(Some(code));
@@ -149,10 +151,8 @@ impl Audio {
 
     /// Get the sampling rate for the DSP interface.
     fn get_dsp_samplerate() -> SampleRate {
-        unsafe {
-            let r = ogc_sys::AUDIO_GetDSPSampleRate();
-            SampleRate::from_u32(r).unwrap()
-        }
+        let r = unsafe { ogc_sys::AUDIO_GetDSPSampleRate() };
+        SampleRate::from_u32(r).unwrap()
     }
 
     /// Set the sample rate for the streaming audio interface.
@@ -171,10 +171,8 @@ impl Audio {
 
     /// Get the play state from the streaming audio interface.
     fn get_playstate() -> PlayState {
-        unsafe {
-            let r = ogc_sys::AUDIO_GetStreamPlayState();
-            PlayState::from_u32(r).unwrap()
-        }
+        let r = unsafe { ogc_sys::AUDIO_GetStreamPlayState() };
+        PlayState::from_u32(r).unwrap()
     }
 
     /// Set the play state for the streaming audio interface.

--- a/ogc-rs/src/audio.rs
+++ b/ogc-rs/src/audio.rs
@@ -46,12 +46,12 @@ impl Audio {
     fn init_dma(data: &[u8]) {
         unsafe {
             // libogc has strict restrictions on data alignment and length.
-            assert_ne!(
+            assert_eq!(
                 32,
                 mem::align_of_val(data),
                 "Data is not aligned correctly."
             );
-            assert_ne!(0, data.len() % 32, "Data length is not a multiple of 32.");
+            assert_eq!(0, data.len() % 32, "Data length is not a multiple of 32.");
 
             ogc_sys::AUDIO_InitDMA(data.as_ptr() as u32, data.len() as u32);
         }

--- a/ogc-rs/src/audio.rs
+++ b/ogc-rs/src/audio.rs
@@ -81,7 +81,7 @@ impl Audio {
     {
         // TODO: Check if this implementation can be changed.
         let ptr = Box::into_raw(callback);
-        
+
         unsafe {
             let code: extern "C" fn(smp_cnt: u32) = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
@@ -99,7 +99,7 @@ impl Audio {
     {
         // TODO: Check if this implementation can be changed.
         let ptr = Box::into_raw(callback);
-        
+
         unsafe {
             let code: extern "C" fn() = mem::transmute(ptr);
             // TODO: Do something with the returned callback.

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -31,22 +31,20 @@ impl Console {
 
     /// Initialize stdout console.
     pub fn init_stdout(xorigin: i32, yorigin: i32, width: i32, height: i32) -> Result<()> {
-        unsafe {
-            let init = ogc_sys::CON_InitEx(
-                ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()),
-                xorigin,
-                yorigin,
-                width,
-                height,
-            );
+        let init = unsafe { ogc_sys::CON_InitEx(
+            ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()),
+            xorigin,
+            yorigin,
+            width,
+            height,
+        )};
 
-            if init < 0 {
-                Err(OgcError::Console(
-                    "Failed to allocate memory for framebuffer!".into(),
-                ))
-            } else {
-                Ok(())
-            }
+        if init < 0 {
+            Err(OgcError::Console(
+                "Failed to allocate memory for framebuffer!".into(),
+            ))
+        } else {
+            Ok(())
         }
     }
 

--- a/ogc-rs/src/console.rs
+++ b/ogc-rs/src/console.rs
@@ -31,13 +31,15 @@ impl Console {
 
     /// Initialize stdout console.
     pub fn init_stdout(xorigin: i32, yorigin: i32, width: i32, height: i32) -> Result<()> {
-        let init = unsafe { ogc_sys::CON_InitEx(
-            ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()),
-            xorigin,
-            yorigin,
-            width,
-            height,
-        )};
+        let init = unsafe {
+            ogc_sys::CON_InitEx(
+                ogc_sys::VIDEO_GetPreferredMode(ptr::null_mut()),
+                xorigin,
+                yorigin,
+                width,
+                height,
+            )
+        };
 
         if init < 0 {
             Err(OgcError::Console(

--- a/ogc-rs/src/network.rs
+++ b/ogc-rs/src/network.rs
@@ -222,14 +222,12 @@ pub struct HostInformation {
 /// to an integer value suitable for use as an Internet address.
 /// The converted address will be in Network Byte Order.
 pub fn dot_to_nbo(dot: &str) -> Result<IPV4Address> {
-    unsafe {
-        let r = ogc_sys::inet_addr(dot.as_ptr());
+    let r = unsafe { ogc_sys::inet_addr(dot.as_ptr()) };
 
-        if r == 0 {
-            Err(OgcError::Network("network dot_to_nbo failed".to_string()))
-        } else {
-            Ok(IPV4Address { address: r })
-        }
+    if r == 0 {
+        Err(OgcError::Network("network dot_to_nbo failed".to_string()))
+    } else {
+        Ok(IPV4Address { address: r })
     }
 }
 
@@ -237,29 +235,25 @@ pub fn dot_to_nbo(dot: &str) -> Result<IPV4Address> {
 /// to a network address, and stores the address in the structure provided.
 /// The converted address will be in Network Byte Order.
 pub fn dot_to_net_addr(dot: &str, addr: &mut IPV4Address) -> Result<()> {
-    unsafe {
-        let r = ogc_sys::inet_aton(dot.as_ptr(), addr.into());
+    let r = unsafe { ogc_sys::inet_aton(dot.as_ptr(), addr.into()) };
 
-        if r < 0 {
-            Err(OgcError::Network(format!("network dot_to_net_addr: {}", r)))
-        } else {
-            Ok(())
-        }
+    if r < 0 {
+        Err(OgcError::Network(format!("network dot_to_net_addr: {}", r)))
+    } else {
+        Ok(())
     }
 }
 
 /// This function call converts the specified Internet host address
 /// to a string in the Internet standard dot notation.
 pub fn addr_to_dot(addr: &mut IPV4Address) -> Result<String> {
-    unsafe {
-        let r = ogc_sys::inet_ntoa(addr.into());
-        let r = raw_to_string(r);
+    let r = unsafe { ogc_sys::inet_ntoa(addr.into()) };
+    let r = raw_to_string(r);
 
-        if r.is_empty() {
-            Err(OgcError::Network("addr_to_dot empty".to_string()))
-        } else {
-            Ok(r)
-        }
+    if r.is_empty() {
+        Err(OgcError::Network("addr_to_dot empty".to_string()))
+    } else {
+        Ok(r)
     }
 }
 
@@ -294,27 +288,23 @@ pub struct Network;
 impl Network {
     /// Initialization of the networking service.
     pub fn init() -> Result<Self> {
-        unsafe {
-            let r = ogc_sys::net_init();
+        let r = unsafe { ogc_sys::net_init() };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network init: {}", r)))
-            } else {
-                Ok(Self)
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network init: {}", r)))
+        } else {
+            Ok(Self)
         }
     }
 
     /// Create a socket.
     pub fn new(domain: ProtocolFamily, socket_type: SocketType) -> Result<Socket> {
-        unsafe {
-            let r = ogc_sys::net_socket(domain.to_u32().unwrap(), socket_type.to_u32().unwrap(), 0);
+        let r = unsafe { ogc_sys::net_socket(domain.to_u32().unwrap(), socket_type.to_u32().unwrap(), 0) };
 
-            if r == INVALID_SOCKET {
-                Err(OgcError::Network(format!("network socket creation: {}", r)))
-            } else {
-                Ok(Socket(r))
-            }
+        if r == INVALID_SOCKET {
+            Err(OgcError::Network(format!("network socket creation: {}", r)))
+        } else {
+            Ok(Socket(r))
         }
     }
 }
@@ -328,106 +318,90 @@ pub struct Socket(i32);
 impl Socket {
     /// Initiate a connection on a socket.
     pub fn connect(&self, socket_addr: SocketAddress, address_length: u32) -> Result<()> {
-        unsafe {
-            let r = ogc_sys::net_connect(self.0, socket_addr.into(), address_length);
+        let r = unsafe { ogc_sys::net_connect(self.0, socket_addr.into(), address_length) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network socket connect: {}", r)))
-            } else {
-                Ok(())
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network socket connect: {}", r)))
+        } else {
+            Ok(())
         }
     }
 
     /// Assign a local protocol address to a socket.
     pub fn bind(&self, socket_addr: SocketAddress, address_length: u32) -> Result<()> {
-        unsafe {
-            let r = ogc_sys::net_bind(self.0, socket_addr.into(), address_length);
+        let r = unsafe { ogc_sys::net_bind(self.0, socket_addr.into(), address_length) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network socket bind: {}", r)))
-            } else {
-                Ok(())
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network socket bind: {}", r)))
+        } else {
+            Ok(())
         }
     }
 
     /// This function is called only by a TCP server to listen for the client request.
     pub fn listen(&self, backlog: u32) -> Result<()> {
-        unsafe {
-            let r = ogc_sys::net_listen(self.0, backlog);
+        let r = unsafe { ogc_sys::net_listen(self.0, backlog) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network socket listen: {}", r)))
-            } else {
-                Ok(())
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network socket listen: {}", r)))
+        } else {
+            Ok(())
         }
     }
 
     /// The accept function is called by a TCP server to accept client requests and
     /// to establish actual connection.
     pub fn accept(&self, socket_addr: SocketAddress, address_length: &mut u32) -> Result<i32> {
-        unsafe {
-            let r = ogc_sys::net_accept(self.0, socket_addr.into(), address_length);
+        let r = unsafe { ogc_sys::net_accept(self.0, socket_addr.into(), address_length) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network socket accept: {}", r)))
-            } else {
-                Ok(r)
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network socket accept: {}", r)))
+        } else {
+            Ok(r)
         }
     }
 
     /// Write to the file descriptor, in this case the socket.
     pub fn write(descriptor: i32, buffer: &[u8], count: i32) -> Result<i32> {
-        unsafe {
-            let r = ogc_sys::net_write(descriptor, buffer.as_ptr() as *const c_void, count);
+        let r = unsafe { ogc_sys::net_write(descriptor, buffer.as_ptr() as *const c_void, count) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network writing failure: {}", r)))
-            } else {
-                Ok(r)
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network writing failure: {}", r)))
+        } else {
+            Ok(r)
         }
     }
 
     /// Send data over stream sockets or CONNECTED datagram sockets.
     pub fn send(descriptor: i32, buffer: &[u8], length: i32, flags: u32) -> Result<i32> {
-        unsafe {
-            let r = ogc_sys::net_send(descriptor, buffer.as_ptr() as *const c_void, length, flags);
+        let r = unsafe { ogc_sys::net_send(descriptor, buffer.as_ptr() as *const c_void, length, flags) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network sending failure: {}", r)))
-            } else {
-                Ok(r)
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network sending failure: {}", r)))
+        } else {
+            Ok(r)
         }
     }
 
     /// Read from the file descriptor, in this case the socket.
     pub fn read(descriptor: i32, buffer: &mut [u8], count: i32) -> Result<i32> {
-        unsafe {
-            let r = ogc_sys::net_read(descriptor, buffer.as_ptr() as *mut c_void, count);
+        let r = unsafe { ogc_sys::net_read(descriptor, buffer.as_ptr() as *mut c_void, count) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network reading failure: {}", r)))
-            } else {
-                Ok(r)
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network reading failure: {}", r)))
+        } else {
+            Ok(r)
         }
     }
 
     /// Receive data over stream sockets or CONNECTED datagram sockets.
     pub fn recieve(descriptor: i32, buffer: &mut [u8], length: i32, flags: u32) -> Result<i32> {
-        unsafe {
-            let r = ogc_sys::net_recv(descriptor, buffer.as_ptr() as *mut c_void, length, flags);
+        let r = unsafe { ogc_sys::net_recv(descriptor, buffer.as_ptr() as *mut c_void, length, flags) };
 
-            if r < 0 {
-                Err(OgcError::Network(format!("network recieve failure: {}", r)))
-            } else {
-                Ok(r)
-            }
+        if r < 0 {
+            Err(OgcError::Network(format!("network recieve failure: {}", r)))
+        } else {
+            Ok(r)
         }
     }
 }

--- a/ogc-rs/src/network.rs
+++ b/ogc-rs/src/network.rs
@@ -299,7 +299,9 @@ impl Network {
 
     /// Create a socket.
     pub fn new(domain: ProtocolFamily, socket_type: SocketType) -> Result<Socket> {
-        let r = unsafe { ogc_sys::net_socket(domain.to_u32().unwrap(), socket_type.to_u32().unwrap(), 0) };
+        let r = unsafe {
+            ogc_sys::net_socket(domain.to_u32().unwrap(), socket_type.to_u32().unwrap(), 0)
+        };
 
         if r == INVALID_SOCKET {
             Err(OgcError::Network(format!("network socket creation: {}", r)))
@@ -374,7 +376,9 @@ impl Socket {
 
     /// Send data over stream sockets or CONNECTED datagram sockets.
     pub fn send(descriptor: i32, buffer: &[u8], length: i32, flags: u32) -> Result<i32> {
-        let r = unsafe { ogc_sys::net_send(descriptor, buffer.as_ptr() as *const c_void, length, flags) };
+        let r = unsafe {
+            ogc_sys::net_send(descriptor, buffer.as_ptr() as *const c_void, length, flags)
+        };
 
         if r < 0 {
             Err(OgcError::Network(format!("network sending failure: {}", r)))
@@ -396,7 +400,8 @@ impl Socket {
 
     /// Receive data over stream sockets or CONNECTED datagram sockets.
     pub fn recieve(descriptor: i32, buffer: &mut [u8], length: i32, flags: u32) -> Result<i32> {
-        let r = unsafe { ogc_sys::net_recv(descriptor, buffer.as_ptr() as *mut c_void, length, flags) };
+        let r =
+            unsafe { ogc_sys::net_recv(descriptor, buffer.as_ptr() as *mut c_void, length, flags) };
 
         if r < 0 {
             Err(OgcError::Network(format!("network recieve failure: {}", r)))

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -113,40 +113,34 @@ impl System {
 
     /// Create and initialize sysalarm structure.
     pub fn create_alarm(context: &mut u32) -> Result<()> {
-        unsafe {
-            let r = ogc_sys::SYS_CreateAlarm(context);
+        let r = unsafe { ogc_sys::SYS_CreateAlarm(context) };
 
-            if r < 0 {
-                Err(OgcError::System("system failed to create alarm".into()))
-            } else {
-                Ok(())
-            }
+        if r < 0 {
+            Err(OgcError::System("system failed to create alarm".into()))
+        } else {
+            Ok(())
         }
     }
 
     /// Cancel the alarm, but do not remove from the list of contexts.
     pub fn cancel_alarm(context: u32) -> Result<()> {
-        unsafe {
-            let r = ogc_sys::SYS_CancelAlarm(context);
+        let r = unsafe { ogc_sys::SYS_CancelAlarm(context) };
 
-            if r < 0 {
-                Err(OgcError::System("system failed to cancel alarm".into()))
-            } else {
-                Ok(())
-            }
+        if r < 0 {
+            Err(OgcError::System("system failed to cancel alarm".into()))
+        } else {
+            Ok(())
         }
     }
 
     /// Remove the given alarm context from the list of contexts and destroy it.
     pub fn remove_alarm(context: u32) -> Result<()> {
-        unsafe {
-            let r = ogc_sys::SYS_RemoveAlarm(context);
+        let r = unsafe { ogc_sys::SYS_RemoveAlarm(context) };
 
-            if r < 0 {
-                Err(OgcError::System("system failed to remove alarm".into()))
-            } else {
-                Ok(())
-            }
+        if r < 0 {
+            Err(OgcError::System("system failed to remove alarm".into()))
+        } else {
+            Ok(())
         }
     }
 
@@ -355,9 +349,10 @@ impl System {
 
     /// Set Reset Callback
     pub fn set_reset_callback<F>(callback: Box<F>) {
+        // TODO: Check if this implementation can be changed.
+        let ptr = Box::into_raw(callback);
+        
         unsafe {
-            // TODO: Check if this implementation can be changed.
-            let ptr = Box::into_raw(callback);
             let code: extern "C" fn(irq: u32, ctx: *mut c_void) = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
             let _ = ogc_sys::SYS_SetResetCallback(Some(code));
@@ -366,9 +361,10 @@ impl System {
 
     /// Set Power Callback
     pub fn set_power_callback<F>(callback: Box<F>) {
+        // TODO: Check if this implementation can be changed.
+        let ptr = Box::into_raw(callback);
+        
         unsafe {
-            // TODO: Check if this implementation can be changed.
-            let ptr = Box::into_raw(callback);
             let code: extern "C" fn() = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
             let _ = ogc_sys::SYS_SetPowerCallback(Some(code));

--- a/ogc-rs/src/system.rs
+++ b/ogc-rs/src/system.rs
@@ -153,7 +153,7 @@ impl System {
             // Convert Duration to timespec
             let timespec: *const ogc_sys::timespec = &ogc_sys::timespec {
                 tv_sec: fire_time.as_secs() as i64,
-                tv_nsec: fire_time.as_nanos() as i32
+                tv_nsec: fire_time.as_nanos() as i32,
             };
 
             // TODO: Check if this implementation can be changed.
@@ -184,12 +184,12 @@ impl System {
             // Convert Duration to timespec
             let timespec_start: *const ogc_sys::timespec = &ogc_sys::timespec {
                 tv_sec: time_start.as_secs() as i64,
-                tv_nsec: time_start.as_nanos() as i32
+                tv_nsec: time_start.as_nanos() as i32,
             };
 
             let timespec_period: *const ogc_sys::timespec = &ogc_sys::timespec {
                 tv_sec: time_period.as_secs() as i64,
-                tv_nsec: time_period.as_nanos() as i32
+                tv_nsec: time_period.as_nanos() as i32,
             };
 
             // TODO: Check if this implementation can be changed.
@@ -351,7 +351,7 @@ impl System {
     pub fn set_reset_callback<F>(callback: Box<F>) {
         // TODO: Check if this implementation can be changed.
         let ptr = Box::into_raw(callback);
-        
+
         unsafe {
             let code: extern "C" fn(irq: u32, ctx: *mut c_void) = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
@@ -363,7 +363,7 @@ impl System {
     pub fn set_power_callback<F>(callback: Box<F>) {
         // TODO: Check if this implementation can be changed.
         let ptr = Box::into_raw(callback);
-        
+
         unsafe {
             let code: extern "C" fn() = mem::transmute(ptr);
             // TODO: Do something with the returned callback.

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -5,24 +5,19 @@ use core::slice;
 
 /// Converts a raw *mut u8 into a String.
 pub fn raw_to_string(raw: *mut u8) -> String {
-    unsafe {
-        let slice = slice::from_raw_parts(raw, 1);
-        String::from_utf8(slice.to_vec()).unwrap()
-    }
+    let slice = unsafe { slice::from_raw_parts(raw, 1) };
+    String::from_utf8(slice.to_vec()).unwrap()
 }
 
 /// Converts a raw *mut *mut u8 into a String vector.
 pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
-    unsafe {
-        let slice = slice::from_raw_parts(raw, 2);
-        slice
-            .iter()
-            .map(|x: &*mut u8| {
-                let r = slice::from_raw_parts(*x, 1);
-                String::from_utf8(r.to_vec()).unwrap()
-            })
-            .collect()
-    }
+    let slice = unsafe { slice::from_raw_parts(raw, 2) };
+    slice.iter()
+        .map(|x: &*mut u8| {
+            let r = unsafe { slice::from_raw_parts(*x, 1) };
+            String::from_utf8(r.to_vec()).unwrap()
+        })
+        .collect()
 }
 
 /// OS memory casting macros.

--- a/ogc-rs/src/utils.rs
+++ b/ogc-rs/src/utils.rs
@@ -12,7 +12,8 @@ pub fn raw_to_string(raw: *mut u8) -> String {
 /// Converts a raw *mut *mut u8 into a String vector.
 pub fn raw_to_strings(raw: *mut *mut u8) -> Vec<String> {
     let slice = unsafe { slice::from_raw_parts(raw, 2) };
-    slice.iter()
+    slice
+        .iter()
         .map(|x: &*mut u8| {
             let r = unsafe { slice::from_raw_parts(*x, 1) };
             String::from_utf8(r.to_vec()).unwrap()

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -181,7 +181,7 @@ impl Video {
         F: Fn(u32) -> (),
     {
         let ptr = Box::into_raw(callback);
-        
+
         unsafe {
             let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
 
@@ -194,7 +194,7 @@ impl Video {
         F: Fn(u32) -> (),
     {
         let ptr = Box::into_raw(callback);
-        
+
         unsafe {
             let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
 

--- a/ogc-rs/src/video.rs
+++ b/ogc-rs/src/video.rs
@@ -144,29 +144,18 @@ impl Video {
     }
 
     pub fn get_tv_mode() -> TVMode {
-        unsafe {
-            let mode = ogc_sys::VIDEO_GetCurrentTvMode();
-            TVMode::from_u32(mode).unwrap()
-        }
+        let mode = unsafe { ogc_sys::VIDEO_GetCurrentTvMode() };
+        TVMode::from_u32(mode).unwrap()
     }
 
     pub fn get_next_field() -> ViField {
-        unsafe {
-            let next_field = ogc_sys::VIDEO_GetNextField();
-            ViField::from_u32(next_field).unwrap()
-        }
+        let next_field = unsafe { ogc_sys::VIDEO_GetNextField() };
+        ViField::from_u32(next_field).unwrap()
     }
 
     pub fn is_component_cable() -> bool {
-        unsafe {
-            let component = ogc_sys::VIDEO_HaveComponentCable();
-
-            if component == 1 {
-                true
-            } else {
-                false
-            }
-        }
+        let component = unsafe { ogc_sys::VIDEO_HaveComponentCable() };
+        component == 1
     }
 
     pub fn set_black(is_black: bool) {
@@ -191,8 +180,9 @@ impl Video {
     where
         F: Fn(u32) -> (),
     {
+        let ptr = Box::into_raw(callback);
+        
         unsafe {
-            let ptr = Box::into_raw(callback);
             let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
 
             let _ = ogc_sys::VIDEO_SetPostRetraceCallback(Some(code));
@@ -203,8 +193,9 @@ impl Video {
     where
         F: Fn(u32) -> (),
     {
+        let ptr = Box::into_raw(callback);
+        
         unsafe {
-            let ptr = Box::into_raw(callback);
             let code: extern "C" fn(vi_retrace_callback: u32) = mem::transmute(ptr);
 
             let _ = ogc_sys::VIDEO_SetPreRetraceCallback(Some(code));


### PR DESCRIPTION
This PR is pretty simple:
+ Reduces the amount of code covered by `unsafe` blocks
+ Fixes a logic error in `Audio::init_dma()`

The logic error is a result of asserting that the length and alignment of the data are **not** their required values, rather than asserting that they **are**.

Note that even with this fix, the alignment check still doesn't work because `mem::align_of_val()` returns the minimum alignment needed for the type, which for `&[u8]` is always 1. I'll submit a separate PR that fixes this.