### PR TITLE
Add CullMode enum

### DIFF
--- a/examples/embedded-graphics-wii/src/display.rs
+++ b/examples/embedded-graphics-wii/src/display.rs
@@ -10,7 +10,7 @@ use embedded_graphics::{
 use ogc_rs::{
     ffi::{
         GX_Color4u8, Mtx, GX_ALWAYS, GX_AOP_AND, GX_BL_INVSRCALPHA, GX_BL_SRCALPHA, GX_BM_BLEND,
-        GX_CLIP_ENABLE, GX_CLR_RGBA, GX_COLOR0A0, GX_CULL_NONE, GX_DIRECT, GX_F32, GX_FALSE,
+        GX_CLIP_ENABLE, GX_CLR_RGBA, GX_COLOR0A0, GX_DIRECT, GX_F32, GX_FALSE,
         GX_GM_1_0, GX_GREATER, GX_LEQUAL, GX_LO_CLEAR, GX_MAX_Z24, GX_NONE, GX_ORTHOGRAPHIC,
         GX_PASSCLR, GX_PF_RGB8_Z24, GX_PNMTX0, GX_POS_XYZ, GX_QUADS, GX_RGBA8, GX_TEVSTAGE0,
         GX_TEXCOORD0, GX_TEXMAP0, GX_TEX_ST, GX_TRUE, GX_VA_CLR0, GX_VA_POS, GX_VA_TEX0,
@@ -143,7 +143,7 @@ impl Display {
         Gx::set_alpha_update(GX_TRUE as _);
         Gx::set_alpha_compare(GX_GREATER as _, 0, GX_AOP_AND as _, GX_ALWAYS as _, 0);
         Gx::set_color_update(GX_TRUE as _);
-        Gx::set_cull_mode(GX_CULL_NONE as _);
+        Gx::set_cull_mode(CullMode::None);
 
         Gx::set_clip_mode(GX_CLIP_ENABLE as _);
         Gx::set_scissor(

--- a/ogc-sys/src/ogc.rs
+++ b/ogc-sys/src/ogc.rs
@@ -2742,6 +2742,60 @@ pub struct _card_dir {
 #[doc = "\\param company[2] string identifier <=2."]
 #[doc = "\\param showall boolean flag whether to showall entries or ony those identified by card_gamecode and card_company, previously set within the call to CARD_Init()"]
 pub type card_dir = _card_dir;
+#[doc = " \\typedef struct card_direntry"]
+#[doc = "\\brief structure to hold the information of the save file entry ( aka GCI )"]
+#[doc = "\\param gamecode[4] string identifier <=4."]
+#[doc = "\\param company[2] string identifier <=2."]
+#[doc = "\\param padding always 0xFF."]
+#[doc = "\\param banner_fmt format of banner."]
+#[doc = "\\param filename[CARD_FILENAMELEN] name of the file on card."]
+#[doc = "\\param last_modified last time it was modified,in seconds since 1970 in seconds."]
+#[doc = "\\param icon_addr icon image address in file."]
+#[doc = "\\param icon_fmt icon image format."]
+#[doc = "\\param icon_speed speed of an animated icon."]
+#[doc = "\\param permission permissions of the save file."]
+#[doc = "\\param copy_times how many times the save file has been copied."]
+#[doc = "\\param block starting block of the save file."]
+#[doc = "\\param length size of the save file.."]
+#[doc = "\\param padding always 0xFFFF."]
+#[doc = "\\param comment_addr address in file of the comment block."]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _card_direntry {
+    pub gamecode: [u8_; 4usize],
+    pub company: [u8_; 2usize],
+    pub pad_00: u8_,
+    pub banner_fmt: u8_,
+    pub filename: [u8_; 32usize],
+    pub last_modified: u32_,
+    pub icon_addr: u32_,
+    pub icon_fmt: u16_,
+    pub icon_speed: u16_,
+    pub permission: u8_,
+    pub copy_times: u8_,
+    pub block: u16_,
+    pub length: u16_,
+    pub pad_01: u16_,
+    pub comment_addr: u32_,
+}
+#[doc = " \\typedef struct card_direntry"]
+#[doc = "\\brief structure to hold the information of the save file entry ( aka GCI )"]
+#[doc = "\\param gamecode[4] string identifier <=4."]
+#[doc = "\\param company[2] string identifier <=2."]
+#[doc = "\\param padding always 0xFF."]
+#[doc = "\\param banner_fmt format of banner."]
+#[doc = "\\param filename[CARD_FILENAMELEN] name of the file on card."]
+#[doc = "\\param last_modified last time it was modified,in seconds since 1970 in seconds."]
+#[doc = "\\param icon_addr icon image address in file."]
+#[doc = "\\param icon_fmt icon image format."]
+#[doc = "\\param icon_speed speed of an animated icon."]
+#[doc = "\\param permission permissions of the save file."]
+#[doc = "\\param copy_times how many times the save file has been copied."]
+#[doc = "\\param block starting block of the save file."]
+#[doc = "\\param length size of the save file.."]
+#[doc = "\\param padding always 0xFFFF."]
+#[doc = "\\param comment_addr address in file of the comment block."]
+pub type card_direntry = _card_direntry;
 #[doc = " \\typedef struct card_stat"]
 #[doc = "\\brief structure to hold the additional statistical informations."]
 #[doc = "\\param filename[CARD_FILENAMELEN] name of the file on card."]
@@ -2750,6 +2804,7 @@ pub type card_dir = _card_dir;
 #[doc = "\\param company[2] string identifier <=2."]
 #[doc = "\\param banner_fmt format of banner."]
 #[doc = "\\param icon_addr icon image address in file."]
+#[doc = "\\param icon_fmt icon image format."]
 #[doc = "\\param icon_speed speed of an animated icon."]
 #[doc = "\\param comment_addr address in file of the comment block."]
 #[doc = "\\param offset_banner offset in file to the banner's image data."]
@@ -2786,6 +2841,7 @@ pub struct _card_stat {
 #[doc = "\\param company[2] string identifier <=2."]
 #[doc = "\\param banner_fmt format of banner."]
 #[doc = "\\param icon_addr icon image address in file."]
+#[doc = "\\param icon_fmt icon image format."]
 #[doc = "\\param icon_speed speed of an animated icon."]
 #[doc = "\\param comment_addr address in file of the comment block."]
 #[doc = "\\param offset_banner offset in file to the banner's image data."]
@@ -3130,6 +3186,16 @@ extern "C" {
     pub fn CARD_GetStatus(chn: s32, fileno: s32, stats: *mut card_stat) -> s32;
 }
 extern "C" {
+    #[doc = " \\fn s32 CARD_GetStatusEx(s32 chn, s32 fileno, card_direntry *entry)"]
+    #[doc = "\\brief Get the directory entry (GCI header)"]
+    #[doc = "\\param[in] chn CARD slot."]
+    #[doc = "\\param[in] fileno file index. returned by a previous call to CARD_Open()."]
+    #[doc = "\\param[out] entry pointer to receive the directory entry."]
+    #[doc = ""]
+    #[doc = "\\return \\ref card_errors \"card error codes\""]
+    pub fn CARD_GetStatusEx(chn: s32, fileno: s32, entry: *mut card_direntry) -> s32;
+}
+extern "C" {
     #[doc = " \\fn s32 CARD_SetStatus(s32 chn,s32 fileno,card_stat *stats)"]
     #[doc = "\\brief Set additional file statistic informations. Synchronous version."]
     #[doc = "\\param[in] chn CARD slot."]
@@ -3154,6 +3220,15 @@ extern "C" {
         stats: *mut card_stat,
         callback: cardcallback,
     ) -> s32;
+}
+extern "C" {
+    #[doc = " \\fn s32 CARD_SetStatusEx(s32 chn, s32 fileno, card_direntry *entry)"]
+    #[doc = "\\brief Set the directory entry (preferably from a GCI header), except block index and lenght"]
+    #[doc = "\\param[in] chn CARD slot."]
+    #[doc = "\\param[in] fileno file index. returned by a previous call to CARD_Open()."]
+    #[doc = "\\param[out] entry pointer to a directory entry structure (or GCI header)."]
+    #[doc = "\\return \\ref card_errors \"card error codes\""]
+    pub fn CARD_SetStatusEx(chn: s32, fileno: s32, entry: *mut card_direntry) -> s32;
 }
 extern "C" {
     #[doc = " \\fn s32 CARD_GetAttributes(s32 chn,s32 fileno,u8 *attr)"]
@@ -3210,6 +3285,22 @@ extern "C" {
     #[doc = ""]
     #[doc = "\\return \\ref card_errors \"card error codes\""]
     pub fn CARD_SetGamecode(gamecode: *const ::libc::c_char) -> s32;
+}
+extern "C" {
+    #[doc = " \\fn s32 CARD_GetSerialNo(s32 chn, u32 *serial1, u32 *serial2)"]
+    #[doc = "\\brief Get the encrypted serial numbers of the memory card"]
+    #[doc = "\\param[in] chn CARD slot."]
+    #[doc = "\\param[in] serial1 & serial2 CARD slot."]
+    #[doc = "\\return \\ref card_errors \"card error codes\" or free blocks"]
+    pub fn CARD_GetSerialNo(chn: s32, serial1: *mut u32_, serial2: *mut u32_) -> s32;
+}
+extern "C" {
+    #[doc = " \\fn s32 CARD_GetFreeBlocks(s32 chn, u16* freeblocks)"]
+    #[doc = "\\brief Get the free blocks in memory card"]
+    #[doc = "\\param[in] chn CARD slot."]
+    #[doc = "\\param[in] freeblocks pointer to receive freeblocks value."]
+    #[doc = "\\return \\ref card_errors \"card error codes\" or free blocks"]
+    pub fn CARD_GetFreeBlocks(chn: s32, freeblocks: *mut u16_) -> s32;
 }
 #[doc = "\\typedef struct _gx_rmodeobj GXRModeObj"]
 #[doc = "\\brief structure to hold the selected video and render settings"]
@@ -10140,7 +10231,7 @@ pub struct _tmd {
     pub title_version: u16_,
     pub num_contents: u16_,
     pub boot_index: u16_,
-    pub fill3: u16_,
+    pub fill2: u16_,
     pub contents: __IncompleteArrayField<tmd_content>,
 }
 pub type tmd = _tmd;

--- a/src/gx.rs
+++ b/src/gx.rs
@@ -23,11 +23,11 @@ impl Color {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-#[repr(u8)]
 /// Backface culling mode.
 ///
 /// Primitives in which the vertex order is clockwise to the viewer are considered front-facing.
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
 pub enum CullMode {
     /// Do not cull any primitives.
     None = 0,
@@ -126,7 +126,7 @@ impl Gx {
     /// Enables or disables culling of geometry based on its orientation to the viewer.
     ///
     /// Primitives in which the vertex order is clockwise to the viewer are considered front-facing.
-    /// 
+    ///
     /// See [GX_SetCullMode](https://libogc.devkitpro.org/gx_8h.html#adb4b17c39b24073c3e961458ecf02e87) for more.
     pub fn set_cull_mode(mode: CullMode) {
         unsafe { ogc_sys::GX_SetCullMode(mode as u8) }

--- a/src/gx.rs
+++ b/src/gx.rs
@@ -23,6 +23,22 @@ impl Color {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+/// Backface culling mode.
+///
+/// Primitives in which the vertex order is clockwise to the viewer are considered front-facing.
+pub enum CullMode {
+    /// Do not cull any primitives.
+    None = 0,
+    /// Cull front-facing primitives.
+    Front = 1,
+    /// Cull back-facing primitives.
+    Back = 2,
+    /// Cull all primitives.
+    All = 3,
+}
+
 /// Represents the GX service.
 pub struct Gx;
 
@@ -108,9 +124,12 @@ impl Gx {
     }
 
     /// Enables or disables culling of geometry based on its orientation to the viewer.
+    ///
+    /// Primitives in which the vertex order is clockwise to the viewer are considered front-facing.
+    /// 
     /// See [GX_SetCullMode](https://libogc.devkitpro.org/gx_8h.html#adb4b17c39b24073c3e961458ecf02e87) for more.
-    pub fn set_cull_mode(mode: u8) {
-        unsafe { ogc_sys::GX_SetCullMode(mode) }
+    pub fn set_cull_mode(mode: CullMode) {
+        unsafe { ogc_sys::GX_SetCullMode(mode as u8) }
     }
 
     /// Copies the embedded framebuffer (EFB) to the external framebuffer(XFB) in main memory.


### PR DESCRIPTION
Still getting familiar with the codebase, so I decided to do something simple.

This change adds a `CullMode` enum that can be passed to `Gx::set_cull_mode()`. It helps abstract away the numeric value that corresponds to each mode.

This also includes some changes that seem to be from `libogc`. Hopefully that's not a problem.