### PR TITLE
:recycle: refactor(input and ogc-sys): Dont use CLANG_VERSION anymore and added and refactor stuff to input.rs

### DIFF
--- a/ogc-sys/build.rs
+++ b/ogc-sys/build.rs
@@ -4,9 +4,9 @@ use regex::Regex;
 use std::env;
 use std::process::Command;
 
-fn get_clang_version() -> String {
+ fn get_clang_version() -> String {
     // Check if the clang version env variable exists.
-   {
+    if env::var("CLANG_VERSION").is_err() {
         // Attempt to retrieve clang version through the command line.
         let clang_output = match Command::new("clang").arg("--version").output() {
             Ok(output) => output,
@@ -36,6 +36,10 @@ fn get_clang_version() -> String {
 
         // Return the final joined string.
         version.to_string()
+    } else {
+        // Clang version env variable exists, use that over parsing.
+        env::var("CLANG_VERSION").unwrap()
+    }
 }
 
 fn main() {

--- a/ogc-sys/build.rs
+++ b/ogc-sys/build.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 fn get_clang_version() -> String {
     // Check if the clang version env variable exists.
-    if env::var("CLANG_VERSION").is_err() {
+   {
         // Attempt to retrieve clang version through the command line.
         let clang_output = match Command::new("clang").arg("--version").output() {
             Ok(output) => output,
@@ -36,10 +36,6 @@ fn get_clang_version() -> String {
 
         // Return the final joined string.
         version.to_string()
-    } else {
-        // Clang version env variable exists, use that over parsing.
-        env::var("CLANG_VERSION").unwrap()
-    }
 }
 
 fn main() {


### PR DESCRIPTION
Removed the use of CLANG_VERSION environment variable.
Added is_button_down, is_button_held and is_button_up. 
Added ir functionality. 
Made RawData::Wii an option of wpad_data instead of box.

**THIS CHANGES HOW OGC-SYS IS BUILT**