### PR TITLE
Matrix revamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +253,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "libm",
  "num_enum",
  "ogc-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bitflags = "1.2"
 num_enum = { version = "0.5", default-features = false }
 cfg-if = "1.0"
 
+libm = "0.2"
 libc = "0.2"
 ogc-sys = { version = "0.4.2", path = "ogc-sys" }
 

--- a/examples/embedded-graphics-wii/Cargo.lock
+++ b/examples/embedded-graphics-wii/Cargo.lock
@@ -251,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +326,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "libm",
  "num_enum",
  "ogc-sys",
 ]

--- a/examples/embedded-graphics-wii/src/display.rs
+++ b/examples/embedded-graphics-wii/src/display.rs
@@ -104,7 +104,7 @@ impl Display {
             GX_COLOR0A0 as _,
         );
         Gu::mtx_identity(&mut ident);
-        Gu::mtx_trans_apply(&mut ident.clone(), &mut ident, 0.0, 0.0, -100.0);
+        Gu::mtx_translation_apply(&mut ident.clone(), &mut ident, (0.0, 0.0, -100.0));
         Gx::load_pos_mtx_imm(&mut ident, GX_PNMTX0 as _);
 
         let mut perspective: ogc_rs::ffi::Mtx44 = [[0f32; 4]; 4];

--- a/examples/embedded-graphics-wii/src/display.rs
+++ b/examples/embedded-graphics-wii/src/display.rs
@@ -10,9 +10,8 @@ use embedded_graphics::{
 use ogc_rs::{
     ffi::{
         Mtx, GX_CLR_RGBA, GX_COLOR0A0, GX_DIRECT, GX_F32, GX_GM_1_0, GX_MAX_Z24, GX_NONE,
-        GX_ORTHOGRAPHIC, GX_PASSCLR, GX_PF_RGB8_Z24, GX_PNMTX0, GX_POS_XYZ, GX_RGBA8, GX_TEVSTAGE0,
-        GX_TEXCOORD0, GX_TEXMAP0, GX_TEX_ST, GX_VA_CLR0, GX_VA_POS, GX_VA_TEX0, GX_VTXFMT0,
-        GX_ZC_LINEAR,
+        GX_PASSCLR, GX_PF_RGB8_Z24, GX_PNMTX0, GX_POS_XYZ, GX_RGBA8, GX_TEVSTAGE0, GX_TEXCOORD0,
+        GX_TEXMAP0, GX_TEX_ST, GX_VA_CLR0, GX_VA_POS, GX_VA_TEX0, GX_VTXFMT0, GX_ZC_LINEAR,
     },
     mem_cached_to_uncached,
     prelude::*,
@@ -119,7 +118,7 @@ impl Display {
             0.0,
             1000.0,
         );
-        Gx::load_projection_mtx(&mut perspective, GX_ORTHOGRAPHIC as _);
+        Gx::load_projection_mtx(&mut perspective, ProjectionType::Orthographic);
 
         Gx::set_viewport(
             0.0,

--- a/examples/embedded-graphics-wii/src/main.rs
+++ b/examples/embedded-graphics-wii/src/main.rs
@@ -66,15 +66,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
             0.0,
         );
 
-        let raw = match wii_ctrl.get_raw() {
-            RawData::Wii(raw) => Some(raw),
-            _ => None,
-        };
-
-        let ir = Point::new(
-            raw.as_ref().unwrap().ir.x as i32,
-            raw.as_ref().unwrap().ir.y as i32,
-        );
+        let ir = Point::new(wii_ctrl.ir().0 as i32, wii_ctrl.ir().1 as i32);
 
         BACKGROUND
             .into_styled(PrimitiveStyle::with_fill(Rgb888::WHITE))

--- a/examples/template/Cargo.lock
+++ b/examples/template/Cargo.lock
@@ -193,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +253,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "libm",
  "num_enum",
  "ogc-sys",
 ]

--- a/src/gu.rs
+++ b/src/gu.rs
@@ -253,16 +253,16 @@ impl Gu {
         unsafe { ffi::c_guMtxRotTrig(mt.as_mut_ptr().cast(), axis as u8, sin, cos) }
     }
 
-    pub fn mtx_rotation_axis_radians(mt: &mut Mtx34, axis: &mut guVector, rot_radians: f32) {
-        unsafe { ffi::c_guMtxRotAxisRad(mt.as_mut_ptr().cast(), axis, rot_radians) }
+    pub fn mtx_rotation_axis_radians(mt: &mut Mtx34, axis: (f32, f32, f32), rot_radians: f32) {
+        unsafe { ffi::c_guMtxRotAxisRad(mt.as_mut_ptr().cast(), &mut guVector { x: axis.0, y: axis.1, z: axis.2 } , rot_radians) }
     }
 
-    pub fn mtx_reflect(mt: &mut Mtx34, point: &mut guVector, normal: &mut guVector) {
-        unsafe { ffi::c_guMtxReflect(mt.as_mut_ptr().cast(), point, normal) }
+    pub fn mtx_reflect(mt: &mut Mtx34, point: (f32, f32, f32), normal: (f32, f32, f32)) {
+        unsafe { ffi::c_guMtxReflect(mt.as_mut_ptr().cast(), &mut guVector {x: point.0, y: point.1, z: point.2}, &mut guVector {x: normal.0, y: normal.1, z: normal.2}) }
     }
 
-    pub fn mtx_quaternion(mt: &mut Mtx34, quaternion: &mut guQuaternion) {
-        unsafe { ffi::c_guMtxQuat(mt.as_mut_ptr().cast(), quaternion) }
+    pub fn mtx_quaternion(mt: &mut Mtx34, quaternion: (f32, f32, f32, f32)) {
+        unsafe { ffi::c_guMtxQuat(mt.as_mut_ptr().cast(), &mut guQuaternion {x: quaternion.0, y: quaternion.1, z: quaternion.2, w: quaternion.3}) }
     }
 }
 

--- a/src/gx.rs
+++ b/src/gx.rs
@@ -178,6 +178,13 @@ pub enum BlendCtrl {
     Zero = ffi::GX_BL_ZERO as _,
 }
 
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+pub enum ProjectionType {
+    Perspective = ffi::GX_PERSPECTIVE as _,
+    Orthographic = ffi::GX_ORTHOGRAPHIC as _,
+}
+
 /// Represents the GX service.
 pub struct Gx;
 
@@ -340,8 +347,8 @@ impl Gx {
 
     /// Sets the projection matrix.
     /// See [GX_LoadProjectionMtx](https://libogc.devkitpro.org/gx_8h.html#a241a1301f006ed04b7895c051959f64e) for more.
-    pub fn load_projection_mtx(mt: &mut Mtx44, p_type: u8) {
-        unsafe { ffi::GX_LoadProjectionMtx(mt as *mut _, p_type) }
+    pub fn load_projection_mtx(mt: &mut Mtx44, p_type: ProjectionType) {
+        unsafe { ffi::GX_LoadProjectionMtx(mt as *mut _, p_type as u8) }
     }
 
     /// Invalidates the vertex cache.


### PR DESCRIPTION
Add structure based function for use if people want to use them instead of Gu::function(&mut matrix).
Make load_projection_mtx take a ProjectionType instead of a u8.
Fix and Cargo format.