### PR TITLE
ASND & AESND moving and actual usage

### DIFF
--- a/src/asnd.rs
+++ b/src/asnd.rs
@@ -4,7 +4,7 @@
 
 use crate::{ffi, OgcError, Result};
 use alloc::format;
-use core::{mem, time::Duration};
+use core::time::Duration;
 
 macro_rules! if_not {
     ($valid:ident => $error_output:expr, $var:ident $(,)*) => {
@@ -362,8 +362,8 @@ impl Asnd {
 
     fn validate_buffer(sound_buffer: &mut [u8]) {
         assert_eq!(
-            32,
-            mem::align_of_val(sound_buffer),
+            0,
+            sound_buffer.as_ptr().align_offset(32),
             "Data is not aligned correctly."
         );
         assert_eq!(


### PR DESCRIPTION
- fix(ASND): Properly check for 32 byte alignment for buffers
- feat: :sparkles: Make pub and move alloc_sound_buffer to alloc_aligned_buffer.

Some Notes:
- ASND doesnt allocate the aligned buffer. This is still a user responsibility. 
- `alloc_aligned_buffer` should just be a struct that have an inner [u8], however I don't know how to that properly
-  Having asnd allocate it's own buffer seems to mess with the music somehow. I think its a lifetime issue. 