### PR TITLE
Gx refactor round 2 and a half plus some

### DIFF
--- a/examples/embedded-graphics-wii/Cargo.lock
+++ b/examples/embedded-graphics-wii/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
@@ -33,21 +33,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "az"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822d7d63e0c0260a050f6b1f0d316f5c79b9eab830aca526ed904e1011bd64ca"
+checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
 
 [[package]]
 name = "bindgen"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -67,22 +67,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.1"
+name = "bit_field"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
+name = "bitflags"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "byteorder"
@@ -92,9 +86,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cexpr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
 ]
@@ -107,9 +101,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -118,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -132,15 +126,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "cstr_core"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "cty",
+ "memchr",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embedded-graphics"
@@ -157,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics-core"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3902d8d4422aa9ac75556f8cfb2e02c8ba22eb3f1993aec8bc113e6299b2da"
+checksum = "b8b1239db5f3eeb7e33e35bd10bd014e7b2537b17e071f726a09351431337cfa"
 dependencies = [
  "az",
  "byteorder",
@@ -175,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -194,12 +199,6 @@ checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "glob"
@@ -236,15 +235,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -252,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "log"
@@ -267,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "micromath"
@@ -278,14 +277,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4010833aea396656c2f91ee704d51a6f1329ec2ab56ffd00bfd56f7481ea94"
 
 [[package]]
-name = "nom"
-version = "6.1.2"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec",
- "funty",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -300,19 +304,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2c8fd66061a707503d515639b8af10fd3807a5b5ee6959f7ff1bd303634bd5"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "derivative",
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474fd1d096da3ad17084694eebed40ba09c4a36c5255cd772bd8b98859cc562e"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -321,10 +324,12 @@ dependencies = [
 
 [[package]]
 name = "ogc-rs"
-version = "0.7.1"
+version = "0.1.0"
 dependencies = [
+ "bit_field",
  "bitflags",
  "cfg-if",
+ "cstr_core",
  "libc",
  "libm",
  "num_enum",
@@ -334,7 +339,9 @@ dependencies = [
 
 [[package]]
 name = "ogc-sys"
-version = "0.4.2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6483bd412db6c1b601f70732232ac3aa779f47914da4db78525d86abacf01002"
 dependencies = [
  "bindgen",
  "libc",
@@ -349,33 +356,27 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -396,9 +397,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "shlex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "strsim"
@@ -408,9 +409,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -418,16 +419,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -443,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -461,9 +456,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "voladdress"
@@ -473,10 +468,12 @@ checksum = "5e1c00b315fa5b67ca61aa4b7ac802c92a014813e5c4c8dc77e2aee6d30527ae"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
+ "either",
+ "lazy_static",
  "libc",
 ]
 
@@ -510,9 +507,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/examples/embedded-graphics-wii/Cargo.toml
+++ b/examples/embedded-graphics-wii/Cargo.toml
@@ -1,4 +1,3 @@
-cargo-features = ["strip"]
 
 [package]
 name = "embedded-graphics-wii"

--- a/examples/embedded-graphics-wii/src/main.rs
+++ b/examples/embedded-graphics-wii/src/main.rs
@@ -12,9 +12,8 @@ use embedded_graphics::{
     primitives::{PrimitiveStyle, Rectangle},
     Drawable,
 };
+
 use ogc_rs::prelude::*;
-//use tinytga::Tga;
-//const IMG: &[u8] = include_bytes!("../img.tga");
 
 #[start]
 fn main(_argc: isize, _argv: *const *const u8) -> isize {
@@ -24,11 +23,15 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     let gcn_ctrl = Input::new(ControllerType::Gamecube, ControllerPort::One);
     let wii_ctrl = Input::new(ControllerType::Wii, ControllerPort::One);
-    wii_ctrl.as_wpad().set_data_format(WPadDataFormat::ButtonsAccelIR);
+    wii_ctrl
+        .as_wpad()
+        .set_data_format(WPadDataFormat::ButtonsAccelIR);
 
     Console::init(&video);
-    Video::configure(video.render_config);
-    unsafe { Video::set_next_framebuffer(video.framebuffer); }
+    Video::configure(&video.render_config);
+    unsafe {
+        Video::set_next_framebuffer(video.framebuffer);
+    }
     Video::set_black(true);
     Video::flush();
     Video::wait_vsync();
@@ -47,7 +50,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     const POINTER: Rectangle = Rectangle::new(Point::zero(), Size::new_equal(10));
     loop {
         Input::update(ControllerType::Gamecube);
-        Input::update(ControllerType::Wii); 
+        Input::update(ControllerType::Wii);
 
         if gcn_ctrl.is_button_down(Button::Start) {
             break 0;
@@ -65,7 +68,10 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
             0.0,
         );
 
-        let ir = Point::new(wii_ctrl.as_wpad().ir().0 as i32, wii_ctrl.as_wpad().ir().1 as i32);
+        let ir = Point::new(
+            wii_ctrl.as_wpad().ir().0 as i32,
+            wii_ctrl.as_wpad().ir().1 as i32,
+        );
 
         BACKGROUND
             .into_styled(PrimitiveStyle::with_fill(Rgb888::WHITE))
@@ -95,7 +101,9 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
         wii_display.flush(video.framebuffer);
 
-        unsafe { Video::set_next_framebuffer(video.framebuffer); }
+        unsafe {
+            Video::set_next_framebuffer(video.framebuffer);
+        }
         Video::flush();
         Video::wait_vsync();
     }

--- a/examples/template/Cargo.lock
+++ b/examples/template/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+
+[[package]]
 name = "bitflags"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,22 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "cstr_core"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+dependencies = [
+ "cty",
+ "memchr",
+]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "derivative"
@@ -248,10 +270,12 @@ dependencies = [
 
 [[package]]
 name = "ogc-rs"
-version = "0.7.1"
+version = "0.1.0"
 dependencies = [
+ "bit_field",
  "bitflags",
  "cfg-if",
+ "cstr_core",
  "libc",
  "libm",
  "num_enum",
@@ -261,7 +285,9 @@ dependencies = [
 
 [[package]]
 name = "ogc-sys"
-version = "0.4.2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6483bd412db6c1b601f70732232ac3aa779f47914da4db78525d86abacf01002"
 dependencies = [
  "bindgen",
  "libc",

--- a/examples/template/Cargo.toml
+++ b/examples/template/Cargo.toml
@@ -1,4 +1,3 @@
-cargo-features = ["strip"]
 
 [package]
 name = "template"

--- a/examples/template/src/main.rs
+++ b/examples/template/src/main.rs
@@ -14,8 +14,10 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let wii_ctrl = Input::new(ControllerType::Wii, ControllerPort::One);
 
     Console::init(&video);
-    Video::configure(video.render_config);
-    unsafe  { Video::set_next_framebuffer(video.framebuffer); }
+    Video::configure(&video.render_config);
+    unsafe {
+        Video::set_next_framebuffer(video.framebuffer);
+    }
     Video::set_black(false);
     Video::flush();
     Video::wait_vsync();
@@ -24,7 +26,7 @@ fn main(_argc: isize, _argv: *const *const u8) -> isize {
 
     loop {
         Input::update(ControllerType::Gamecube);
-        Input::update(ControllerType::Wii); 
+        Input::update(ControllerType::Wii);
 
         if gcn_ctrl.is_button_down(Button::Start) {
             break 0;

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -1636,8 +1636,12 @@ impl Gx {
 
     /// Sets the format of pixels in the Embedded Frame Buffer (EFB).
     /// See [GX_SetPixelFmt](https://libogc.devkitpro.org/gx_8h.html#a018d9b0359f9689ac41f44f0b2374ffb) for more.
-    pub fn set_pixel_fmt(pix_fmt: u8, z_fmt: ZCompress) {
-        unsafe { ffi::GX_SetPixelFmt(pix_fmt, z_fmt as u8) }
+    pub fn set_pixel_fmt(pix_fmt: PixelFormat, z_fmt: ZFormat) {
+        let pe_ctrl = PixelEngineControl::new()
+            .pixel_format(pix_fmt)
+            .z_format(z_fmt);
+
+        BPReg::PE_CTRL.load(pe_ctrl.to_u32());
     }
 
     /// Enables or disables culling of geometry based on its orientation to the viewer.

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -1595,14 +1595,62 @@ impl Gx {
         vf: bool,
         v_filter: &mut [u8; 7],
     ) {
-        unsafe {
-            ffi::GX_SetCopyFilter(
-                aa as u8,
-                sample_pattern as *mut _,
-                vf as u8,
-                v_filter as *mut _,
-            )
+        let mut disp_copy_0 = 0x666666u32;
+        let mut disp_copy_1 = 0x666666u32;
+        let mut disp_copy_2 = 0x666666u32;
+        let mut disp_copy_3 = 0x666666u32;
+
+        let mut trgt_copy_0 = 0x595000u32;
+        let mut trgt_copy_1 = 0x000015u32;
+
+        if aa {
+            disp_copy_0.set_bits(0..4, sample_pattern[0][0].into());
+            disp_copy_0.set_bits(4..8, sample_pattern[0][1].into());
+            disp_copy_0.set_bits(8..12, sample_pattern[1][0].into());
+            disp_copy_0.set_bits(12..16, sample_pattern[1][1].into());
+            disp_copy_0.set_bits(16..20, sample_pattern[2][0].into());
+            disp_copy_0.set_bits(20..24, sample_pattern[2][1].into());
+
+            disp_copy_1.set_bits(0..4, sample_pattern[3][0].into());
+            disp_copy_1.set_bits(4..8, sample_pattern[3][1].into());
+            disp_copy_1.set_bits(8..12, sample_pattern[4][0].into());
+            disp_copy_1.set_bits(12..16, sample_pattern[4][1].into());
+            disp_copy_1.set_bits(16..20, sample_pattern[5][0].into());
+            disp_copy_1.set_bits(20..24, sample_pattern[5][1].into());
+
+            disp_copy_2.set_bits(0..4, sample_pattern[6][0].into());
+            disp_copy_2.set_bits(4..8, sample_pattern[6][1].into());
+            disp_copy_2.set_bits(8..12, sample_pattern[7][0].into());
+            disp_copy_2.set_bits(12..16, sample_pattern[7][1].into());
+            disp_copy_2.set_bits(16..20, sample_pattern[8][0].into());
+            disp_copy_2.set_bits(20..24, sample_pattern[8][1].into());
+
+            disp_copy_3.set_bits(0..4, sample_pattern[9][0].into());
+            disp_copy_3.set_bits(4..8, sample_pattern[9][1].into());
+            disp_copy_3.set_bits(8..12, sample_pattern[10][0].into());
+            disp_copy_3.set_bits(12..16, sample_pattern[10][1].into());
+            disp_copy_3.set_bits(16..20, sample_pattern[11][0].into());
+            disp_copy_3.set_bits(20..24, sample_pattern[11][1].into());
         }
+
+        if vf {
+            trgt_copy_0.set_bits(0..6, v_filter[0].into());
+            trgt_copy_0.set_bits(6..12, v_filter[1].into());
+            trgt_copy_0.set_bits(12..18, v_filter[2].into());
+            trgt_copy_0.set_bits(18..24, v_filter[3].into());
+
+            trgt_copy_1.set_bits(0..6, v_filter[4].into());
+            trgt_copy_1.set_bits(6..12, v_filter[5].into());
+            trgt_copy_1.set_bits(12..18, v_filter[6].into());
+        }
+
+        BPReg::DISP_COPY_FILT0.load(disp_copy_0);
+        BPReg::DISP_COPY_FILT1.load(disp_copy_1);
+        BPReg::DISP_COPY_FILT2.load(disp_copy_2);
+        BPReg::DISP_COPY_FILT3.load(disp_copy_3);
+
+        BPReg::TRGT_COPY_FILT0.load(trgt_copy_0);
+        BPReg::TRGT_COPY_FILT1.load(trgt_copy_1);
     }
 
     /// Sets the lighting controls for a particular color channel.

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -16,7 +16,7 @@ use crate::gx::regs::BPReg;
 use crate::{lwp, mem_virtual_to_physical};
 
 use self::regs::XFReg;
-use self::types::{PixelEngineControl, PixelFormat, ZFormat};
+use self::types::{Gamma, PixelEngineControl, PixelFormat, VtxDest, ZFormat};
 
 pub const GX_PIPE: VolAddress<u8, (), Safe> = unsafe { VolAddress::new(0xCC00_8000) };
 
@@ -1738,8 +1738,8 @@ impl Gx {
 
     /// Sets the gamma correction applied to pixels during EFB to XFB copy operation.
     /// See [GX_SetDispCopyGamma](https://libogc.devkitpro.org/gx_8h.html#aa8e5bc962cc786b2049345fa698d4efa) for more.
-    pub fn set_disp_copy_gamma(gamma: u8) {
-        unsafe { ffi::GX_SetDispCopyGamma(gamma) }
+    pub fn set_disp_copy_gamma(gamma: Gamma) {
+        unsafe { ffi::GX_SetDispCopyGamma(gamma.0) }
     }
 
     /// Sets the attribute format (vtxattr) for a single attribute in the Vertex Attribute Table (VAT).
@@ -1896,8 +1896,8 @@ impl Gx {
 
     /// Sets the type of a single attribute (attr) in the current vertex descriptor.
     /// See [GX_SetVtxDesc](https://libogc.devkitpro.org/gx_8h.html#af41b45011ae731ae5697b26b2bf97e2f) for more.
-    pub fn set_vtx_desc(attr: VtxAttr, v_type: u8) {
-        unsafe { ffi::GX_SetVtxDesc(attr as u8, v_type) }
+    pub fn set_vtx_desc(attr: VtxAttr, v_type: VtxDest) {
+        unsafe { ffi::GX_SetVtxDesc(attr as u8, v_type.0) }
     }
 
     /// Used to load a 3x4 modelview matrix mt into matrix memory at location pnidx.

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -15,10 +15,12 @@ use crate::gx::regs::BPReg;
 use crate::{lwp, mem_virtual_to_physical};
 
 use self::regs::XFReg;
+use self::types::{PixelEngineControl, PixelFormat, ZFormat};
 
 pub const GX_PIPE: VolAddress<u8, (), Safe> = unsafe { VolAddress::new(0xCC00_8000) };
 
 mod regs;
+pub mod types;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]

--- a/src/gx/regs.rs
+++ b/src/gx/regs.rs
@@ -230,9 +230,8 @@ impl BPReg {
         assert!(val <= 0xFFFFFF);
         GX_PIPE.write(GPCommand::LoadBPReg as u8);
         GX_PIPE.write(self.0);
-
         //We only want the bottom 24 bits so we only grab the bottom 3 bytes
-        for byte in &val.to_be_bytes()[0..2] {
+        for byte in &val.to_be_bytes()[1..=3] {
             GX_PIPE.write(*byte);
         }
     }

--- a/src/gx/regs.rs
+++ b/src/gx/regs.rs
@@ -79,7 +79,8 @@ impl BPReg {
     pub const EFB_ADDR_TOP_LEFT: Self = Self(0x49);
     pub const EFB_ADDR_DIMENSIONS: Self = Self(0x4A);
     pub const XFB_ADDR: Self = Self(0x4B);
-    // 0x4C - 0x4D
+    // 0x4C
+    pub const MIPMAP_STRIDE: Self = Self(0x4D);
     pub const DISP_COPY_Y_SCALE: Self = Self(0x4E);
     pub const PE_CLEAR_AR: Self = Self(0x4F);
     pub const PE_CLEAR_GB: Self = Self(0x50);

--- a/src/gx/types.rs
+++ b/src/gx/types.rs
@@ -102,3 +102,9 @@ impl From<u32> for PixelEngineControl {
         }
     }
 }
+
+impl Default for PixelEngineControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/gx/types.rs
+++ b/src/gx/types.rs
@@ -29,6 +29,23 @@ impl ZCompareLocation {
     pub const BEFORE_TEXTURE: Self = Self(true);
 }
 
+pub struct Gamma(pub(crate) u8);
+
+impl Gamma {
+    pub const ONE_ZERO: Self = Self(0);
+    pub const ONE_SEVEN: Self = Self(1);
+    pub const TWO_TWO: Self = Self(2);
+}
+
+pub struct VtxDest(pub(crate) u8);
+
+impl VtxDest {
+    pub const NONE: Self = Self(0);
+    pub const DIRECT: Self = Self(1);
+    pub const INDEX8: Self = Self(2);
+    pub const INDEX16: Self = Self(3);
+}
+
 pub struct PixelEngineControl {
     pixel_format: PixelFormat,
     z_format: ZFormat,

--- a/src/gx/types.rs
+++ b/src/gx/types.rs
@@ -1,0 +1,87 @@
+use bit_field::BitField;
+
+pub struct PixelFormat(u8);
+
+impl PixelFormat {
+    pub const RGB8_Z24: Self = Self(0);
+    pub const RGBA6_Z24: Self = Self(1);
+    pub const RGB565_Z16: Self = Self(2);
+    pub const Z24: Self = Self(3);
+    pub const Y8: Self = Self(4);
+    pub const U8: Self = Self(5);
+    pub const V8: Self = Self(6);
+    pub const YUV420: Self = Self(7);
+}
+
+pub struct ZFormat(u8);
+
+impl ZFormat {
+    pub const LINEAR: Self = Self(0);
+    pub const NEAR: Self = Self(1);
+    pub const MID: Self = Self(2);
+    pub const FAR: Self = Self(3);
+}
+
+pub struct ZCompareLocation(bool);
+
+impl ZCompareLocation {
+    pub const AFTER_TEXTURE: Self = Self(false);
+    pub const BEFORE_TEXTURE: Self = Self(true);
+}
+
+pub struct PixelEngineControl {
+    pixel_format: PixelFormat,
+    z_format: ZFormat,
+    z_comp_loc: ZCompareLocation,
+}
+
+impl PixelEngineControl {
+    pub fn new() -> Self {
+        Self {
+            pixel_format: PixelFormat::RGBA6_Z24,
+            z_format: ZFormat::LINEAR,
+            z_comp_loc: ZCompareLocation::BEFORE_TEXTURE,
+        }
+    }
+
+    pub fn to_u32(&self) -> u32 {
+        let mut pe_ctrl = 0u32;
+
+        pe_ctrl.set_bits(0..=2, self.pixel_format.0.into());
+        pe_ctrl.set_bits(3..=5, self.z_format.0.into());
+        pe_ctrl.set_bit(6, self.z_comp_loc.0);
+
+        pe_ctrl
+    }
+
+    #[must_use]
+    pub fn pixel_format(mut self, format: PixelFormat) -> Self {
+        self.pixel_format = format;
+        self
+    }
+
+    #[must_use]
+    pub fn z_format(mut self, format: ZFormat) -> Self {
+        self.z_format = format;
+        self
+    }
+
+    #[must_use]
+    pub fn z_comp_loc(mut self, z_comp_loc: ZCompareLocation) -> Self {
+        self.z_comp_loc = z_comp_loc;
+        self
+    }
+}
+
+impl From<u32> for PixelEngineControl {
+    fn from(pe_ctrl: u32) -> Self {
+        let pix_fmt = pe_ctrl.get_bits(0..=2);
+        let z_fmt = pe_ctrl.get_bits(3..=5);
+        let z_comp_loc = pe_ctrl.get_bit(6);
+        Self {
+            pixel_format: PixelFormat(pix_fmt.try_into().unwrap()),
+            z_format: ZFormat(z_fmt.try_into().unwrap()),
+            z_comp_loc: ZCompareLocation(z_comp_loc),
+        }
+    }
+}


### PR DESCRIPTION
- feature(GX Registers): :recycle: Change how we setup and load GX Regs
- chore: :art: Cargo format
- feat(GX Registers): :sparkles: Add BP register `MIPMAP_STRIDE`
- fix(GX BP Registers): :bug: Properly get bytes to write to GX_PIPE
- refactor(GX): Add seperate `types` module
- refactor(GX): :recycle: Make `set_disp_copy_dst` and `set_disp_copy_srcc` and `set_copy_clear` use `BPReg`s
- refactor(GX): :recycle: Make `set_pixel_fmt` use new GX types, and `BPReg`
- refactor(GX): :recycle: Make `set_copy_filter` use `BPReg`
- feat(type): Added Gamma & VtxDest types
- refactor(GX): :recycle: `set_disp_copy_gamma` now uses Gamma, and `set_vtx_desc` uses VtxDest

WAIT FOR ME TO FIX THE EXAMPLES BEFORE MERGING SMH
