### PR TITLE
Update 'voladdress' to 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "voladdress"
-version = "0.4.5"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c00b315fa5b67ca61aa4b7ac802c92a014813e5c4c8dc77e2aee6d30527ae"
+checksum = "576fbc7b03f545c62d59d1c27e64d924f1c6e533960fe4f2d6dc653aa1867784"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ libm = "0.2"
 libc = "0.2"
 ogc-sys = "0.1.1"
 glam = { version = "0.19.0", default-features = false, features = ["libm"], optional = true }
-voladdress = "0.4"
+voladdress = "1.2.2"
 bit_field = "0.10.1"

--- a/examples/embedded-graphics-wii/Cargo.lock
+++ b/examples/embedded-graphics-wii/Cargo.lock
@@ -462,9 +462,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "voladdress"
-version = "0.4.5"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c00b315fa5b67ca61aa4b7ac802c92a014813e5c4c8dc77e2aee6d30527ae"
+checksum = "576fbc7b03f545c62d59d1c27e64d924f1c6e533960fe4f2d6dc653aa1867784"
 
 [[package]]
 name = "which"

--- a/examples/template/Cargo.lock
+++ b/examples/template/Cargo.lock
@@ -427,9 +427,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "voladdress"
-version = "0.4.5"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1c00b315fa5b67ca61aa4b7ac802c92a014813e5c4c8dc77e2aee6d30527ae"
+checksum = "576fbc7b03f545c62d59d1c27e64d924f1c6e533960fe4f2d6dc653aa1867784"
 
 [[package]]
 name = "which"


### PR DESCRIPTION
Related to https://github.com/rust-wii/ogc-rs/issues/75 , this updates `voladdress` to the latest non-yanked version.

I'm neither a Rust expert nor a Wii Homebrew expert, nor really an embedded programming expert... just a beginning hobbyist. That said I thought I'd contribute instead of making somebody else do the work. I tested the change by:

- Walking through the code usages of `voladdress` and checking for warnings regarding it's usage.
- Building the examples and running their binaries.

Feel free to tell me if I did anything wrong / need to check something. I'm just trying to contribute :).