### PR TITLE
Fix Callbacks Registration API

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -140,7 +140,7 @@ impl System {
     }
 
     /// Set the alarm parameters for a one-shot alarm, add to the list of alarms and start.
-    pub fn set_alarm<F>(context: u32, fire_time: Duration, callback: Box<F>) -> Result<()>
+    pub fn set_alarm<F>(context: u32, fire_time: Duration, callback: extern "C" fn(alarm: u32, cb_arg: *mut c_void)) -> Result<()>
     where
         F: Fn(u32, *mut c_void),
     {
@@ -152,9 +152,7 @@ impl System {
             };
 
             // TODO: Check if this implementation can be changed.
-            let ptr = Box::into_raw(callback);
-            let code: extern "C" fn(alarm: u32, cb_arg: *mut c_void) = mem::transmute(ptr);
-            let r = ffi::SYS_SetAlarm(context, timespec, Some(code), ptr::null_mut());
+            let r = ffi::SYS_SetAlarm(context, timespec, Some(callback), ptr::null_mut());
 
             if r < 0 {
                 Err(OgcError::System("system failed to set alarm".into()))

--- a/src/system.rs
+++ b/src/system.rs
@@ -371,6 +371,9 @@ impl System {
     }
 
     /// Set Reset Callback
+    ///
+    /// Note: `ctx` is always null in the current version of libogc,
+    /// but is still a required parameter.
     pub fn set_reset_callback(callback: extern "C" fn(irq: u32, ctx: *mut c_void)) {
         unsafe {
             // TODO: Do something with the returned callback.

--- a/src/system.rs
+++ b/src/system.rs
@@ -373,26 +373,18 @@ impl System {
     }
 
     /// Set Reset Callback
-    pub fn set_reset_callback<F>(callback: Box<F>) {
-        // TODO: Check if this implementation can be changed.
-        let ptr = Box::into_raw(callback);
-
+    pub fn set_reset_callback(callback: extern "C" fn(irq: u32, ctx: *mut c_void)) {
         unsafe {
-            let code: extern "C" fn(irq: u32, ctx: *mut c_void) = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
-            let _ = ffi::SYS_SetResetCallback(Some(code));
+            let _ = ffi::SYS_SetResetCallback(Some(callback));
         }
     }
 
     /// Set Power Callback
-    pub fn set_power_callback<F>(callback: Box<F>) {
-        // TODO: Check if this implementation can be changed.
-        let ptr = Box::into_raw(callback);
-
+    pub fn set_power_callback(callback: extern "C" fn()) {
         unsafe {
-            let code: extern "C" fn() = mem::transmute(ptr);
             // TODO: Do something with the returned callback.
-            let _ = ffi::SYS_SetPowerCallback(Some(code));
+            let _ = ffi::SYS_SetPowerCallback(Some(callback));
         }
     }
 


### PR DESCRIPTION
As far as I can tell, the current implementation takes a pointer to a function pointer and `mem::transmute`s it into a function pointer. Even if it does work when called correctly, it still allows a box of *anything* to be turned into a function pointer, which is definitely unsafe. Requiring the function pointer passed to be `extern "C"` is inconvenient, since it means closures can't be used (though I have written a macro for fudging it, not included in this PR), but the ABI of `extern "Rust"` function pointers is not guaranteed to be the same.