### PR TITLE
fix feature start removal for all exemples

### DIFF
--- a/examples/colored-tri/src/main.rs
+++ b/examples/colored-tri/src/main.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(start)]
 
 use core::mem::ManuallyDrop;
 
@@ -15,8 +14,8 @@ use ogc_rs::{
 
 extern crate alloc;
 
-#[start]
-fn main(_argc: isize, _argv: *const *const u8) -> isize {
+
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let vi = Video::init();
     let mut config = Video::get_preferred_mode();
 

--- a/examples/embedded-graphics-wii/src/main.rs
+++ b/examples/embedded-graphics-wii/src/main.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(start)]
 
 mod display;
 use crate::display::Display;
@@ -15,8 +14,7 @@ use embedded_graphics::{
 
 use ogc_rs::prelude::*;
 
-#[start]
-fn main(_argc: isize, _argv: *const *const u8) -> isize {
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let mut video = Video::init();
     Input::init(ControllerType::Gamecube);
     Input::init(ControllerType::Wii);

--- a/examples/ios/src/main.rs
+++ b/examples/ios/src/main.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(start)]
 
 use alloc::vec;
 use ogc_rs::{
@@ -9,8 +8,7 @@ use ogc_rs::{
 
 extern crate alloc;
 
-#[start]
-fn main(_argc: isize, _argv: *const *const u8) -> isize {
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     // Try to open SYSCONF
     if let Ok(fd) = ios::open(c"/shared2/sys/SYSCONF", Mode::Read) {
         // Try to grab size or default to 0;

--- a/examples/obj-loading/src/main.rs
+++ b/examples/obj-loading/src/main.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(start)]
 
 mod obj;
 use core::f32::consts::PI;
@@ -28,8 +27,7 @@ const WHITE_BYTES: &[u8] = include_bytes!("../white.png");
 #[derive(Clone, Copy)]
 pub struct Align32<T>(pub T);
 
-#[start]
-fn main(_argc: isize, _argv: *const *const u8) -> isize {
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let Ok(obj) = obj::from_bytes(include_bytes!("./assets/untitled.obj")) else {
         panic!()
     };

--- a/examples/template/src/main.rs
+++ b/examples/template/src/main.rs
@@ -1,13 +1,12 @@
 #![no_std]
-#![feature(start)]
 
 extern crate alloc;
 use core::mem::ManuallyDrop;
 
 use ogc_rs::{mp3player::MP3Player, prelude::*};
 
-#[start]
-fn main(_argc: isize, _argv: *const *const u8) -> isize {
+#[no_mangle]
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let mp3 = include_bytes!("../mp3.mp3");
 
     let video = Video::init();

--- a/examples/texture-tri/src/main.rs
+++ b/examples/texture-tri/src/main.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(start)]
 
 use core::{alloc::Layout, mem::ManuallyDrop};
 
@@ -22,8 +21,7 @@ extern crate alloc;
 use alloc::vec;
 const WHITE_BYTES: &[u8] = include_bytes!("../white.png");
 
-#[start]
-fn main(_argc: isize, _argv: *const *const u8) -> isize {
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let vi = Video::init();
     let mut config = Video::get_preferred_mode();
 


### PR DESCRIPTION
As of a recent rust update, feature(start) was removed, forcing to do this small workaround to still have the C main function