### PR TITLE
Additions to debug module and other minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **/*.rs.bk
 **/*.dol
 **/*.o
+
+# Temporary files created by editors
+**/*.swp

--- a/powerpc-unknown-eabi.json
+++ b/powerpc-unknown-eabi.json
@@ -11,6 +11,7 @@
     "linker": "powerpc-eabi-gcc",
     "linker-flavor": "gcc",
     "linker-is-gnu": true,
+    "max-atomic-width": 32,
     "os": "rvl-ios",
     "pre-link-args": {
         "gcc": [
@@ -30,4 +31,3 @@
     "target-pointer-width": "32",
     "vendor": "nintendo"
 }
-

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -4,18 +4,29 @@
 
 use crate::ffi;
 
+/// Default EXI channel. channel can be 0 or 1. Note: Used for device type USBGecko
+pub const DEF_EXICHAN: i32 = ffi::GDBSTUB_DEF_CHANNEL as _;
+
+/// Default TCP port. Note: Used for device type TCP
+pub const DEF_TCPPORT: i32 = ffi::GDBSTUB_DEF_TCPPORT as _;
+
 /// Enum for gdb stub types.
 #[derive(Debug, Eq, PartialEq)]
 #[repr(i32)]
 pub enum GDBStubDevice {
-    Usb = 0,
-    Tcp = 1,
+    /// device type: USBGecko
+    Usb = ffi::GDBSTUB_DEVICE_USB as _,
+    /// device type: BBA-TCP
+    Tcp = ffi::GDBSTUB_DEVICE_TCP as _,
 }
 
 /// Performs the initialization of the debug stub.
+///
+/// * `device_type`: type of device to use. can be either USB or TCP.
+/// * `channel_port`: depending on the used device this can be either the EXI channel or the TCP port.
 pub fn debug_init(device_type: GDBStubDevice, channel_port: i32) {
     unsafe {
-        ffi::DEBUG_Init(device_type as i32, channel_port);
+        ffi::DEBUG_Init(device_type as _, channel_port);
     }
 }
 

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -461,14 +461,12 @@ impl Fifo {
     /// The count is incorrect if an overflow has occurred (i.e. you have written more data than
     /// the size of the fifo), as the hardware cannot detect an overflow in general.
     pub fn cache_lines(&self) -> usize {
-        // TODO: remove conversions when upstream changes pass.
-        unsafe { ffi::GX_GetFifoCount(self as *const _ as *mut _) as usize }
+        unsafe { ffi::GX_GetFifoCount(&self.0) as usize }
     }
 
     /// Get the size of a given FIFO.
     pub fn len(&self) -> usize {
-        // TODO: remove conversions when upstream changes pass.
-        unsafe { ffi::GX_GetFifoSize(self as *const _ as *mut _) as usize }
+        unsafe { ffi::GX_GetFifoSize(&self.0) as usize }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -486,7 +484,7 @@ impl Fifo {
     /// If the FIFO write pointer is not explicitly set to the base of the FIFO, you cannot rely on
     /// this function to detect overflows.
     pub fn get_wrap(&self) -> u8 {
-        unsafe { ffi::GX_GetFifoWrap(self as *const _ as *mut _) }
+        unsafe { ffi::GX_GetFifoWrap(&self.0) }
     }
 
     /// Returns the current value of the Graphics FIFO read and write pointers.
@@ -497,7 +495,7 @@ impl Fifo {
         let mut rd_ptr = core::ptr::null_mut();
         let mut wt_ptr = core::ptr::null_mut();
         unsafe {
-            ffi::GX_GetFifoPtrs(self as *const _ as *mut _, &mut rd_ptr, &mut wt_ptr);
+            ffi::GX_GetFifoPtrs(&self.0, &mut rd_ptr, &mut wt_ptr);
         }
         (rd_ptr as *const _, wt_ptr as *mut _)
     }
@@ -927,20 +925,17 @@ impl Texture<'_> {
 
     /// Returns the texture height.
     pub fn height(&self) -> u16 {
-        // TODO: remove conversions when upstream changes pass.
-        unsafe { ffi::GX_GetTexObjHeight(self as *const _ as *mut _) }
+        unsafe { ffi::GX_GetTexObjHeight(&self.0) }
     }
 
     /// Returns the texture width.
     pub fn width(&self) -> u16 {
-        // TODO: remove conversions when upstream changes pass.
-        unsafe { ffi::GX_GetTexObjWidth(self as *const _ as *mut _) }
+        unsafe { ffi::GX_GetTexObjWidth(&self.0) }
     }
 
     /// Returns `true` if the texture's mipmap flag is enabled.
     pub fn is_mipmapped(&self) -> bool {
-        // TODO: remove conversions when upstream changes pass.
-        unsafe { ffi::GX_GetTexObjMipMap(self as *const _ as *mut _) != 0 }
+        unsafe { ffi::GX_GetTexObjMipMap(&self.0) != 0 }
     }
 
     /// Enables bias clamping for texture LOD.
@@ -1216,8 +1211,8 @@ impl Gx {
     ///
     /// The break point mechanism can be used to force the FIFO to stop reading commands at a
     /// certain point; see [`Gx::enable_breakpt()`].
-    pub fn set_gp_fifo(fifo: Fifo) {
-        unsafe { ffi::GX_SetGPFifo((&fifo) as *const _ as *mut _) }
+    pub fn set_gp_fifo(fifo: &mut Fifo) {
+        unsafe { ffi::GX_SetGPFifo(&mut fifo.0) }
     }
 
     /// Attaches a FIFO to the CPU.
@@ -1226,8 +1221,8 @@ impl Gx {
     /// If the FIFO being attached is one already attached to the GP, the FIFO can be considered to
     /// be in immediate mode. If not, the CPU can write commands, and the GP will execute them when
     /// the GP attaches to this FIFO (multi-buffered mode).
-    pub fn set_cpu_fifo(fifo: Fifo) {
-        unsafe { ffi::GX_SetCPUFifo((&fifo) as *const _ as *mut _) }
+    pub fn set_cpu_fifo(fifo: &mut Fifo) {
+        unsafe { ffi::GX_SetCPUFifo(&mut fifo.0) }
     }
 
     /// Returns the current GX thread.
@@ -1387,7 +1382,7 @@ impl Gx {
     ///
     /// Another way to load a light object is with `Gx::load_light_idx()`.
     pub fn load_light(lit_obj: &Light, lit_id: u8) {
-        unsafe { ffi::GX_LoadLightObj(lit_obj as *const _ as *mut _, lit_id) }
+        unsafe { ffi::GX_LoadLightObj(&lit_obj.0, lit_id) }
     }
 
     /// Instructs the GP to fetch the light object at *litobjidx* from an array.
@@ -1789,7 +1784,7 @@ impl Gx {
     /// If the texture is a color-index texture, you **must** load the associated TLUT (using
     /// [`Gx::load_tlut()`]) before calling this function.
     pub fn load_texture(obj: &Texture, mapid: u8) {
-        unsafe { ffi::GX_LoadTexObj((&obj.0) as *const _ as *mut _, mapid) }
+        unsafe { ffi::GX_LoadTexObj(obj as *const _ as *mut _, mapid) }
     }
 
     /// Sets the projection matrix.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 #![feature(negative_impls)]
 #![feature(slice_ptr_get)]
 #![feature(allocator_api)]
-#![feature(strict_provenance)]
 #![feature(asm_experimental_arch)]
 
 extern crate alloc;


### PR DESCRIPTION
Mostly removing some pointer casts in GX and removing the warning for strict provenance.

Also added `max-atomic-width` to the target json [according to the embedonomicon](https://docs.rust-embedded.org/embedonomicon/custom-target.html#fill-the-target-file). I don't know if it's *necessary,* but it still built without errors and I confirmed that the Broadway CPU does support atomics in that size using [LL/SC instructions](https://en.wikipedia.org/wiki/Load-link/store-conditional#Implementations).