### PR TITLE
Fix cargo-doc warnings

### DIFF
--- a/ogc-sys/src/lib.rs
+++ b/ogc-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(rustdoc::broken_intra_doc_links)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -2289,6 +2289,62 @@ impl Gx {
     pub fn end() {
         unsafe { ffi::GX_End() }
     }
+
+    pub fn preload_entire_texture() {
+        unimplemented!()
+    }
+
+    pub fn load_tlut() {
+        unimplemented!()
+    }
+
+    pub fn set_draw_sync() {
+        unimplemented!()
+    }
+
+    pub fn get_draw_sync() {
+        unimplemented!()
+    }
+
+    pub fn set_gp_metric() {
+        unimplemented!()
+    }
+
+    pub fn read_gp_metric() {
+        unimplemented!()
+    }
+
+    pub fn set_vcache_metric() {
+        unimplemented!()
+    }
+
+    pub fn read_vcache_metric() {
+        unimplemented!()
+    }
+
+    pub fn copy_tex() {
+        unimplemented!()
+    }
+
+    pub fn redirect_write_gather_pipe() {
+        unimplemented!()
+    }
+
+    pub fn set_draw_done_callback() {
+        unimplemented!()
+    }
+
+    pub fn set_tex_region_callback() {
+        unimplemented!()
+    }
+
+    pub fn set_tlut_region_callback() {
+        unimplemented!()
+    }
+
+    pub fn set_vtx_descv() {
+        unimplemented!()
+    }
 }
 
 //All the following data is found from
@@ -2361,3 +2417,4 @@ pub enum ColorChannel {
     Color0 = ffi::GX_COLOR0,
     Color1 = ffi::GX_COLOR1,
 }
+

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -32,6 +32,10 @@ pub type LockResult<T> = Result<T, LockError>;
 /// it is protecting. The data can only be accessed through the RAII guards
 /// returned from [`lock`] and [`try_lock`], which guarantees that the data is
 /// only ever accessed when the mutex is locked.
+///
+/// [`new`]: Self::new
+/// [`lock`]: Self::lock
+/// [`try_lock`]: Self::try_lock
 pub struct Mutex<T: ?Sized> {
     inner: ffi::mutex_t,
     data: UnsafeCell<T>,
@@ -207,9 +211,12 @@ impl<T: ?Sized> Drop for Mutex<T> {
 /// dropped (falls out of scope), the lock will be unlocked.
 ///
 /// The data protected by the mutex can be accessed through this guard via its
-/// [`Deref`] and [`DerefMut`] implementations.
+/// `Deref` and `DerefMut` implementations.
 ///
 /// This structure is created by the [`lock`] and [`try_lock`] methods on Mutex.
+///
+/// [`lock`]: Mutex::lock
+/// [`try_lock`]: Mutex::try_lock
 #[must_use = "if unused, the Mutex will immediately unlock"]
 pub struct MutexGuard<'a, T: ?Sized + 'a> {
     lock: &'a Mutex<T>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,7 +49,7 @@ pub mod mem {
 mod console_printing {
     /// Prints to the console video output.
     ///
-    /// Equivalent to the [`println!`] macro except that a newline is not printed at
+    /// Equivalent to the `println!` macro except that a newline is not printed at
     /// the end of the message.
     #[macro_export]
     macro_rules! print {


### PR DESCRIPTION
Currently working to add missing functions, types, and documentation to GX. This subset of changes would fix all the warnings that come up when running `cargo doc`.