### PR TITLE
Update to Rust 2024 + Dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bindgen"
@@ -23,7 +23,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -36,27 +36,21 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.100",
+ "syn",
  "which",
 ]
 
 [[package]]
 name = "bit_field"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "cexpr"
@@ -69,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clang-sys"
@@ -95,42 +89,42 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "glam"
-version = "0.19.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 dependencies = [
- "num-traits",
+ "libm",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,25 +150,25 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -184,15 +178,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -222,22 +216,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -245,7 +240,7 @@ name = "ogc-rs"
 version = "0.1.1"
 dependencies = [
  "bit_field",
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
  "glam",
  "libc",
@@ -267,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "phf"
@@ -301,7 +296,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -315,37 +310,37 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_core",
 ]
@@ -358,9 +353,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -370,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -381,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
@@ -397,12 +392,18 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "shlex"
@@ -412,26 +413,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -440,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "voladdress"
@@ -463,12 +453,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ogc-rs"
 version = "0.1.1"
 authors = ["rust-wii"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 readme = "README.md"
 description = "A Rust wrapper library for devkitPro's libogc"
@@ -13,6 +13,9 @@ keywords = ["wii", "embedded", "no-std"]
 
 [lib]
 crate-type = ["rlib"]
+test = false
+bench = false
+doctest = false
 
 
 [features]
@@ -24,12 +27,12 @@ default_alloc_handler = []
 default_panic_handler = []
 
 [dependencies]
-bitflags = "1.3"
-num_enum = { version = "0.5", default-features = false }
+bitflags = "2.13"
+num_enum = { version = "0.7", default-features = false }
 cfg-if = "1.0"
 libc = "0.2"
 ogc-sys =  { path = "./ogc-sys/"}
-glam = { version = "0.19.0", default-features = false, features = ["libm"], optional = true }
+glam = { version = "0.33", default-features = false, features = ["libm"], optional = true }
 voladdress = "1.4"
 bit_field = "0.10.1"
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,6 @@ keywords = ["wii", "embedded", "no-std"]
 
 [lib]
 crate-type = ["rlib"]
-test = false
-bench = false
-doctest = false
-
 
 [features]
 default = ["default_alloc_handler", "default_panic_handler"]

--- a/src/asnd.rs
+++ b/src/asnd.rs
@@ -2,12 +2,12 @@
 //!
 //! This module implements a safe wrapper around the audio functions found in ``asndlib.h``.
 
-use crate::{ffi, OgcError, Result};
+use crate::{OgcError, Result, ffi};
 use alloc::format;
 use core::time::Duration;
 
 macro_rules! if_not {
-    ($valid:ident => $error_output:expr, $var:ident $(,)*) => {
+    ($valid:ident => $error_output:expr_2021, $var:ident $(,)*) => {
         if $var == ffi::$valid as _ {
             Ok(())
         } else {

--- a/src/console.rs
+++ b/src/console.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements a safe wrapper around the console functions.
 
-use crate::{ffi, video::Video, OgcError, Result};
+use crate::{OgcError, Result, ffi, video::Video};
 use alloc::string::String;
 use core::ptr;
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,12 +5,12 @@
 use crate::ffi;
 
 /// Default EXI channel for use in [`debug_init()`]. Channel can be 0 or 1.
-/// 
+///
 /// **Note**: Used for device type USBGecko
 pub const DEF_EXICHAN: u32 = ffi::GDBSTUB_DEF_CHANNEL;
 
 /// Default TCP port for use in [`debug_init()`].
-/// 
+///
 /// **Note**: Used for device type TCP.
 pub const DEF_TCPPORT: u32 = ffi::GDBSTUB_DEF_TCPPORT;
 

--- a/src/gu.rs
+++ b/src/gu.rs
@@ -9,7 +9,7 @@ use ffi::guQuaternion;
 use num_traits::Float;
 
 use crate::{
-    ffi::{self, guVector, Mtx as Mtx34, Mtx44},
+    ffi::{self, Mtx as Mtx34, Mtx44, guVector},
     gx::{self, Gx},
 };
 

--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -1274,7 +1274,7 @@ impl Gx {
     /// # Safety
     /// This function resets CPU accessible counters, so it should **not** be used in a display list.
     pub unsafe fn clear_gp_metric() {
-        ffi::GX_ClearGPMetric()
+        unsafe { ffi::GX_ClearGPMetric() }
     }
 
     /// Clears the Vertex Cache performance counter.
@@ -1325,7 +1325,7 @@ impl Gx {
     pub unsafe fn set_breakpt_callback(
         cb: Option<unsafe extern "C" fn()>,
     ) -> Option<unsafe extern "C" fn()> {
-        ffi::GX_SetBreakPtCallback(cb)
+        unsafe { ffi::GX_SetBreakPtCallback(cb) }
     }
 
     /// Allows reads from the FIFO currently attached to the Graphics Processor (GP) to resume.
@@ -1345,7 +1345,7 @@ impl Gx {
     /// # Safety
     /// This function should be avoided; use the GP performance metric functions instead.
     pub unsafe fn init_xf_ras_metric() {
-        ffi::GX_InitXfRasMetric()
+        unsafe { ffi::GX_InitXfRasMetric() }
     }
 
     /// Reads the current status of the GP.
@@ -1425,7 +1425,7 @@ impl Gx {
     /// # Safety
     /// This function must be called between successive calls to [`Gx::redirect_write_gather_pipe()`].
     pub unsafe fn restore_write_gather_pipe() {
-        ffi::GX_RestoreWriteGatherPipe()
+        unsafe { ffi::GX_RestoreWriteGatherPipe() }
     }
 
     /// Sends a DrawDone command to the GP.
@@ -1705,7 +1705,7 @@ impl Gx {
     ///
     /// See [GX_CopyDisp](https://libogc.devkitpro.org/gx_8h.html#a9ed0ae3f900abb6af2e930dff7a6bc28) for more.
     pub unsafe fn copy_disp(dest: *mut c_void, clear: bool) {
-        ffi::GX_CopyDisp(dest, clear as u8)
+        unsafe { ffi::GX_CopyDisp(dest, clear as u8) }
     }
 
     /// Sets the gamma correction applied to pixels during EFB to XFB copy operation.

--- a/src/lwp.rs
+++ b/src/lwp.rs
@@ -120,10 +120,7 @@ impl Builder {
         self
     }
 
-    pub fn spawn(
-        self,
-        entry: EntryFn,
-    ) -> Result<Thread, i32> {
+    pub fn spawn(self, entry: EntryFn) -> Result<Thread, i32> {
         let mut thread = core::mem::MaybeUninit::uninit();
         unsafe {
             let res = ffi::LWP_CreateThread(

--- a/src/mmio/command_processor.rs
+++ b/src/mmio/command_processor.rs
@@ -141,7 +141,9 @@ pub unsafe fn write_fifo_base(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo base mmio registers, returning the physical pointer
 pub unsafe fn read_fifo_base() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(FIFO_BASE_ADDRESS_LOW.read(), FIFO_BASE_ADDRESS_HIGH.read())
+    unsafe {
+        AlignedPhysPtr::from_split(FIFO_BASE_ADDRESS_LOW.read(), FIFO_BASE_ADDRESS_HIGH.read())
+    }
 }
 
 /// Write `ptr` to the fifo end mmio registers.
@@ -154,7 +156,7 @@ pub unsafe fn write_fifo_end(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo end mmio registers, returning the physical pointer.
 pub unsafe fn read_fifo_end() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(FIFO_END_ADDRESS_LOW.read(), FIFO_END_ADDRESS_HIGH.read())
+    unsafe { AlignedPhysPtr::from_split(FIFO_END_ADDRESS_LOW.read(), FIFO_END_ADDRESS_HIGH.read()) }
 }
 
 /// Write `ptr` to the fifo low watermark mmio registers.
@@ -167,10 +169,12 @@ pub unsafe fn write_fifo_low_watermark(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo low watermark mmio registers, returning the physical pointer
 pub unsafe fn read_fifo_low_watermark() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(
-        FIFO_LOW_WATERMARK_ADDRESS_LOW.read(),
-        FIFO_LOW_WATERMARK_ADDRESS_HIGH.read(),
-    )
+    unsafe {
+        AlignedPhysPtr::from_split(
+            FIFO_LOW_WATERMARK_ADDRESS_LOW.read(),
+            FIFO_LOW_WATERMARK_ADDRESS_HIGH.read(),
+        )
+    }
 }
 
 /// Write `ptr` to the fifo high watermark mmio registers.
@@ -183,10 +187,12 @@ pub unsafe fn write_fifo_high_watermark(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo read watermark mmio registers, returning the physical pointer
 pub unsafe fn read_fifo_high_watermark() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(
-        FIFO_HIGH_WATERMARK_ADDRESS_LOW.read(),
-        FIFO_HIGH_WATERMARK_ADDRESS_HIGH.read(),
-    )
+    unsafe {
+        AlignedPhysPtr::from_split(
+            FIFO_HIGH_WATERMARK_ADDRESS_LOW.read(),
+            FIFO_HIGH_WATERMARK_ADDRESS_HIGH.read(),
+        )
+    }
 }
 
 /// Write `ptr` to the fifo read pointer mmio registers.
@@ -199,7 +205,9 @@ pub unsafe fn write_fifo_read_ptr(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo read pointer mmio registers, returning the physical pointer
 pub unsafe fn read_fifo_read_ptr() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(FIFO_READ_ADDRESS_LOW.read(), FIFO_READ_ADDRESS_HIGH.read())
+    unsafe {
+        AlignedPhysPtr::from_split(FIFO_READ_ADDRESS_LOW.read(), FIFO_READ_ADDRESS_HIGH.read())
+    }
 }
 
 /// Write `ptr` to the fifo write pointer mmio registers.
@@ -212,10 +220,12 @@ pub unsafe fn write_fifo_write_ptr(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo write pointer mmio registers, returning the physical pointer
 pub unsafe fn read_fifo_write_ptr() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(
-        FIFO_WRITE_ADDRESS_LOW.read(),
-        FIFO_WRITE_ADDRESS_HIGH.read(),
-    )
+    unsafe {
+        AlignedPhysPtr::from_split(
+            FIFO_WRITE_ADDRESS_LOW.read(),
+            FIFO_WRITE_ADDRESS_HIGH.read(),
+        )
+    }
 }
 
 /// Write `ptr` to the fifo breakpoint pointer mmio registers.
@@ -228,10 +238,12 @@ pub unsafe fn write_fifo_breakpoint_ptr(ptr: AlignedPhysPtr<u8>) {
 
 /// Read fifo breakpoint pointer mmio registers, returning the physical pointer
 pub unsafe fn read_fifo_breakpoint_ptr() -> AlignedPhysPtr<u8> {
-    AlignedPhysPtr::from_split(
-        FIFO_BREAKPOINT_ADDRESS_LOW.read(),
-        FIFO_BREAKPOINT_ADDRESS_HIGH.read(),
-    )
+    unsafe {
+        AlignedPhysPtr::from_split(
+            FIFO_BREAKPOINT_ADDRESS_LOW.read(),
+            FIFO_BREAKPOINT_ADDRESS_HIGH.read(),
+        )
+    }
 }
 
 pub(crate) mod types {

--- a/src/network.rs
+++ b/src/network.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::bad_bit_mask)]
 
-use crate::{ffi, OgcError, Result};
+use crate::{OgcError, Result, ffi};
 use alloc::{
     boxed::Box,
     format,
@@ -14,7 +14,7 @@ use alloc::{
 
 use bitflags::bitflags;
 use core::{
-    ffi::{c_void, CStr},
+    ffi::{CStr, c_void},
     slice,
 };
 use num_enum::IntoPrimitive;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,18 +21,22 @@ pub struct OGCAllocator;
 
 unsafe impl GlobalAlloc for OGCAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if layout.size() > 1024 * 1024 * 16 {
-            panic!(
-                "Attempted to allocate >16MB (asked for {} bytes)",
-                layout.size()
-            );
-        } else {
-            libc::memalign(layout.align().max(8), layout.size()).cast::<u8>()
+        unsafe {
+            if layout.size() > 1024 * 1024 * 16 {
+                panic!(
+                    "Attempted to allocate >16MB (asked for {} bytes)",
+                    layout.size()
+                );
+            } else {
+                libc::memalign(layout.align().max(8), layout.size()).cast::<u8>()
+            }
         }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        libc::free(ptr.cast::<libc::c_void>());
+        unsafe {
+            libc::free(ptr.cast::<libc::c_void>());
+        }
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements a safe wrapper around the OS functions found in ``system.h``.
 
-use crate::{ffi, video::RenderConfig, OgcError, Result};
+use crate::{OgcError, Result, ffi, video::RenderConfig};
 use alloc::boxed::Box;
 use core::{ffi::c_void, mem, ptr, time::Duration};
 use num_enum::IntoPrimitive;
@@ -245,7 +245,9 @@ impl System {
         stride: i32,
         width: &mut i32,
     ) {
-        ffi::SYS_GetFontTexel(c, image, position, stride, width);
+        unsafe {
+            ffi::SYS_GetFontTexel(c, image, position, stride, width);
+        }
     }
 
     /// Get Font Texture
@@ -260,7 +262,9 @@ impl System {
         ypos: &mut i32,
         width: &mut i32,
     ) {
-        ffi::SYS_GetFontTexture(c, image, xpos, ypos, width);
+        unsafe {
+            ffi::SYS_GetFontTexture(c, image, xpos, ypos, width);
+        }
     }
 
     /// Get Font Encoding
@@ -280,7 +284,7 @@ impl System {
     /// The user must ensure this point into the memory is valid and the arena doesn't go out
     /// memory
     pub unsafe fn set_arena_1_lo(new_lo: *mut c_void) {
-        ffi::SYS_SetArena1Lo(new_lo)
+        unsafe { ffi::SYS_SetArena1Lo(new_lo) }
     }
 
     /// Get Arena 1 Hi
@@ -295,7 +299,7 @@ impl System {
     /// The user must ensure this point into the memory is valid and the arena doesn't go out
     /// memory
     pub unsafe fn set_arena_1_hi(new_hi: *mut c_void) {
-        ffi::SYS_SetArena1Hi(new_hi)
+        unsafe { ffi::SYS_SetArena1Hi(new_hi) }
     }
 
     /// Get Arena 1 Size
@@ -315,7 +319,7 @@ impl System {
     /// The user must ensure this point into the memory is valid and the arena doesn't go out
     /// memory
     pub unsafe fn set_arena_2_lo(new_lo: *mut c_void) {
-        ffi::SYS_SetArena2Lo(new_lo)
+        unsafe { ffi::SYS_SetArena2Lo(new_lo) }
     }
 
     /// Get Arena 2 Hi
@@ -330,7 +334,7 @@ impl System {
     /// The user must ensure this point into the memory is valid and the arena doesn't go out
     /// memory
     pub unsafe fn set_arena_2_hi(new_hi: *mut c_void) {
-        ffi::SYS_SetArena2Hi(new_hi)
+        unsafe { ffi::SYS_SetArena2Hi(new_hi) }
     }
 
     /// Get Arena 2 Size

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,8 +63,8 @@ mod console_printing {
     #[macro_export]
     macro_rules! println {
         () => (print!("\n"));
-        ($fmt:expr) => (print!(concat!($fmt, "\n")));
-        ($fmt:expr, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
+        ($fmt:expr_2021) => (print!(concat!($fmt, "\n")));
+        ($fmt:expr_2021, $($arg:tt)*) => (print!(concat!($fmt, "\n"), $($arg)*));
     }
 }
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -2,8 +2,8 @@
 //!
 //! This module implements a safe wrapper around video functions.
 
-use crate::{ffi, system::System};
 use crate::utils::mem::to_uncached;
+use crate::{ffi, system::System};
 use alloc::boxed::Box;
 use core::{convert::TryFrom, ffi::c_void, mem, ptr};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -107,10 +107,7 @@ impl Video {
 
             Self {
                 render_config: r_mode,
-                framebuffer:
-                    (System::allocate_framebuffer(
-                        &Self::get_preferred_mode()
-                    ) as *mut u8)
+                framebuffer: (System::allocate_framebuffer(&Self::get_preferred_mode()) as *mut u8)
                     .map_addr(to_uncached) as *mut c_void,
             }
         }
@@ -174,14 +171,18 @@ impl Video {
     ///
     /// The user must ensure this pointer to to valid framebuffer data
     pub unsafe fn set_next_framebuffer(framebuffer: *mut c_void) {
-        ffi::VIDEO_SetNextFramebuffer(framebuffer);
+        unsafe {
+            ffi::VIDEO_SetNextFramebuffer(framebuffer);
+        }
     }
 
     /// # Safety
     ///
     /// The user must ensure this pointer to to valid framebuffer data
     pub unsafe fn set_next_right_framebuffer(framebuffer: *mut c_void) {
-        ffi::VIDEO_SetNextRightFramebuffer(framebuffer);
+        unsafe {
+            ffi::VIDEO_SetNextRightFramebuffer(framebuffer);
+        }
     }
 
     pub fn register_post_retrace_callback<F>(callback: Box<F>)


### PR DESCRIPTION
Full disclaimer: this is the first time I've migrated Rust versions on a project, not sure if I've covered everything. I just followed the `cargo fix` process and then updated the dependency versions to their latest releases. `cargo build` completes successfully, although rust-analyzer is throwing some errors related to a gx function (but this is just rust-analyzer being weird I think). More than willing to discard and reattempt if I've missed some major things, or make changes here if I've missed some smaller things. 

Most of the changes are formatting, and the rest is just wrapping code in `unsafe` blocks.