### PR TITLE
FIx some issues related to modern rust and devkitpro versions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,5 @@
 target = "powerpc-unknown-eabi.json"
 
 [unstable]
+json-target-spec = true
 build-std = ["core", "alloc"]

--- a/ogc-sys/build.rs
+++ b/ogc-sys/build.rs
@@ -4,6 +4,7 @@ use bindgen::callbacks::ParseCallbacks;
 use regex::Regex;
 use std::env;
 use std::process::Command;
+use std::path::Path;
 
 fn get_include_path(dkp_path: String) -> Vec<String>{
 	let mut include = Vec::new();
@@ -167,8 +168,15 @@ fn main() {
 			bindings = bindings.clone().clang_arg(format!("-I{}", include));
 		});
 
+		// libogc is not always installed with the devkitPro toolchain,
+		// so check for it before generating bindings to avoid confusing build failures.
+		let libogc_include = Path::new(&dkp_path).join("libogc/include");
 
-		let bindings = bindings.clang_arg(format!("-I{}/libogc/include", dkp_path))
+		if !libogc_include.exists() {
+			panic!("libogc is not installed.");
+		}
+		
+		let bindings = bindings.clang_arg(format!("-I{}", libogc_include.display()))
 		.clang_arg("-mfloat-abi=hard")
 		.clang_arg("-nostdinc")
 		.clang_arg("-Wno-macro-redefined")

--- a/ogc-sys/build.rs
+++ b/ogc-sys/build.rs
@@ -69,10 +69,40 @@ fn main() {
 	if std::env::var("DOCS_RS").is_ok() || std::env::var("CI").is_ok() {
 		return;
 	}
-	let dkp_path = env::var("DEVKITPRO").expect("devkitPro is needed to use this crate");
+	let dkp_path = env::var("DEVKITPRO").expect("The devkitPRO toolchain is required to use this crate; please verify that your environment variables are correctly configured");
+	let dkppc_path = env::var("DEVKITPPC").expect("The devkitPPC toolchain is required to use this crate; please verify that your environment variables are correctly configured");
+	
+	// DEVKITPPC may contain a Windows path (D:/devkitPro/devkitPPC), but MSYS2
+	// PATH uses Unix-style drive paths (/d/devkitPro/devkitPPC/bin). Using the
+	// wrong format can make powerpc-eabi-gcc unavailable even if installed.
+	//
+	// Convert only the displayed fix; DEVKITPPC remains unchanged for compiler,
+	// include, and linker paths. This check belongs here because ogc-rs is the
+	// first build step that directly requires devkitPPC to generate bindings.
+	let path_hint = if dkppc_path.len() > 2 && dkppc_path.as_bytes()[1] == b':' {
+		format!("/{}/{}", dkppc_path[..1].to_lowercase(), &dkppc_path[3..])
+	} else {
+		dkppc_path.clone()
+	};
+
+	if Command::new("powerpc-eabi-gcc").arg("--version").output().is_err() {
+		panic!(
+			"powerpc-eabi-gcc was not found.\n\
+			devkitPPC's executables are required to be available in PATH.\n\
+			$DEVKITPPC is set, but the compiler cannot be found.\n\
+			This usually means the PATH entry is missing.\n\
+			\n\
+			Add this to a startup configuration file like ~/.bashrc:\n\
+			export PATH=\"{}/bin:$PATH\"\n\
+			\n\
+			\n\
+			After changing the PATH, restart your terminal or reload your shell.",
+			path_hint
+		);
+	}
 	println!(
-		"cargo:rustc-link-search=native={}/devkitPPC/powerpc-eabi/lib",
-		dkp_path
+		"cargo:rustc-link-search=native={}/powerpc-eabi/lib",
+		dkppc_path
 	);
 	println!("cargo:rustc-link-search=native={}/libogc/lib/wii", dkp_path);
 
@@ -122,10 +152,10 @@ fn main() {
 		.blocklist_type("i(8|16|32|64|128)")
 		.blocklist_type("f(32|64)")
 		.clang_arg("--target=powerpc-none-eabi")
-		.clang_arg(format!("--sysroot={}/devkitPPC/powerpc-eabi", dkp_path))
+		.clang_arg(format!("--sysroot={}/powerpc-eabi", dkppc_path))
 		.clang_arg(format!(
-			"-isystem{}/devkitPPC/powerpc-eabi/include",
-			dkp_path
+			"-isystem{}/powerpc-eabi/include",
+			dkppc_path
 		))
 		.clang_arg(format!(
 			"-isystem/usr/lib/clang/{}/include",

--- a/src/network.rs
+++ b/src/network.rs
@@ -210,9 +210,9 @@ pub struct HostInformation {
     /// A NULL-terminated array of alternate names.
     pub aliases: Vec<String>,
     /// The type of address being returned.
-    pub address_type: i16,
+    pub address_type: core::ffi::c_short,
     /// The length, in bytes, of each address.
-    pub length: i16,
+    pub length: core::ffi::c_short,
     /// A NULL-terminated list of addresses for the host.
     pub address_list: Vec<String>,
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -210,9 +210,9 @@ pub struct HostInformation {
     /// A NULL-terminated array of alternate names.
     pub aliases: Vec<String>,
     /// The type of address being returned.
-    pub address_type: i32,
+    pub address_type: i16,
     /// The length, in bytes, of each address.
-    pub length: i32,
+    pub length: i16,
     /// A NULL-terminated list of addresses for the host.
     pub address_list: Vec<String>,
 }


### PR DESCRIPTION
## PR Summary
had some trouble getting this up with the newer rust and devkitpro versions i had. these changes fix several problems that happens on a new installation of rust and devkitpro for me. detailed descriptions are in the commits on why I had to do stuff.

## Additional testing and issues found
after applying these changes, the project compiles correctly on my windows 11 machine. however, when testing the same code on my arch linux laptop, it fails during compilation. the main issue appears to be related to the generated bindings. on arch linux, gforce and _sys_fontheader are only exposing an _address field instead of the expected fields from the libogc ABI. this causes compilation failures because the rust side expects the generated bindings to match the actual libogc structures, but the generated output is for some reason completely wrong.
<details>
  <summary>error output</summary>

```bash
error[E0560]: struct `_sys_fontheader` has no field named `font_type`
  --> src/system.rs:71:13
   |
71 |             font_type: head.font_type,
   |             ^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `first_char`
  --> src/system.rs:72:13
   |
72 |             first_char: head.first_char,
   |             ^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `last_char`
  --> src/system.rs:73:13
   |
73 |             last_char: head.last_char,
   |             ^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `inval_char`
  --> src/system.rs:74:13
   |
74 |             inval_char: head.inval_char,
   |             ^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `asc`
  --> src/system.rs:75:13
   |
75 |             asc: head.asc,
   |             ^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `desc`
  --> src/system.rs:76:13
   |
76 |             desc: head.desc,
   |             ^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `width`
  --> src/system.rs:77:13
   |
77 |             width: head.width,
   |             ^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `leading`
  --> src/system.rs:78:13
   |
78 |             leading: head.leading,
   |             ^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `cell_width`
  --> src/system.rs:79:13
   |
79 |             cell_width: head.cell_dimensions.0,
   |             ^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `cell_height`
  --> src/system.rs:80:13
   |
80 |             cell_height: head.cell_dimensions.1,
   |             ^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_size`
  --> src/system.rs:81:13
   |
81 |             sheet_size: head.sheet_size,
   |             ^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_format`
  --> src/system.rs:82:13
   |
82 |             sheet_format: head.sheet_format,
   |             ^^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_column`
  --> src/system.rs:83:13
   |
83 |             sheet_column: head.sheet_colrow.0,
   |             ^^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_row`
  --> src/system.rs:84:13
   |
84 |             sheet_row: head.sheet_colrow.1,
   |             ^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_width`
  --> src/system.rs:85:13
   |
85 |             sheet_width: head.sheet_dimensions.0,
   |             ^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_height`
  --> src/system.rs:86:13
   |
86 |             sheet_height: head.sheet_dimensions.1,
   |             ^^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `width_table`
  --> src/system.rs:87:13
   |
87 |             width_table: head.width_table,
   |             ^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_image`
  --> src/system.rs:88:13
   |
88 |             sheet_image: head.sheet_image,
   |             ^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `sheet_fullsize`
  --> src/system.rs:89:13
   |
89 |             sheet_fullsize: head.sheet_fullsize,
   |             ^^^^^^^^^^^^^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `c0`
  --> src/system.rs:90:13
   |
90 |             c0: 0,
   |             ^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `c1`
  --> src/system.rs:91:13
   |
91 |             c1: 0,
   |             ^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `c2`
  --> src/system.rs:92:13
   |
92 |             c2: 0,
   |             ^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0560]: struct `_sys_fontheader` has no field named `c3`
  --> src/system.rs:93:13
   |
93 |             c3: 0,
   |             ^^ `_sys_fontheader` does not have this field
   |
   = note: available fields are: `_address`

error[E0609]: no field `x` on type `gforce_t`
   --> src/input/wpad.rs:109:22
    |
109 |         (data.gforce.x, data.gforce.y, data.gforce.z)
    |                      ^ unknown field
    |
    = note: available field is: `_address`

error[E0609]: no field `y` on type `gforce_t`
   --> src/input/wpad.rs:109:37
    |
109 |         (data.gforce.x, data.gforce.y, data.gforce.z)
    |                                     ^ unknown field
    |
    = note: available field is: `_address`

error[E0609]: no field `z` on type `gforce_t`
   --> src/input/wpad.rs:109:52
    |
109 |         (data.gforce.x, data.gforce.y, data.gforce.z)
    |                                                    ^ unknown field
    |
    = note: available field is: `_address`
```
</details>

i am not sure yet if this is caused by different headers being picked up or not during binding generation or some other toolchain/environment difference. it's definitely not differing versions (clang, rust, libogc) based on when I was trying to debug. so, for some reason, the windows 11 environment appears to generate the expected bindings, while the arch linux environment does not for some reason. weird! i'll move this to an issue after this pr is made. but I thought I would like to address that in my PR and if anyone had some pointers on why this is happening.

## Template build issue

also, while trying to test the templates, i also found another separate issue. the templates currently fail during the build script stage because crtresxgpr.o cannot be found:

```bash
thread 'main' panicked at build.rs:25:59:
Could not move crtresxgpr.o: Os { code: 2, kind: NotFound, message: "The system cannot find the file specified." }
```

this seems separate from the rust nightly fixes and the binding issue. the main focus of this pr is getting libogc-rs itself compiling again so im avoiding the remaining platform and template issues. i feel like all the build.rs files on this project need to be really reworked but for now, the library builds successfully on windows 11 on the latest nightly rust (``rustc 1.99.0-nightly (09ee43b2d 2026-07-27)``) now with ease.

that's about it! these should all be trivial and simple to merge, ask me questions if needed.