### PR TITLE
Add `no_main` to the colored-tri example

### DIFF
--- a/examples/colored-tri/src/main.rs
+++ b/examples/colored-tri/src/main.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![no_mangle]
+#![no_main]
 
 use core::mem::ManuallyDrop;
 


### PR DESCRIPTION
Simple enough change, commit acf0148 incorrectly added `no_mangle` as a crate attribute instead of `no_main` for the colored-tri example.