### PR TITLE
Fix template build scripts on Windows

### DIFF
--- a/examples/colored-tri/build.rs
+++ b/examples/colored-tri/build.rs
@@ -15,7 +15,7 @@ fn main() {
 	};
 	let output = libgcc_location.stdout;
 	let parsed_output =
-		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace("\n", "");
+		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace(&['\r', '\n'], "");
 		
 	let _ = match Command::new("powerpc-eabi-ar").arg("x").arg(parsed_output).arg("crtresxfpr.o").arg("crtresxgpr.o").output() {
 		Ok(output) => output,

--- a/examples/embedded-graphics-wii/build.rs
+++ b/examples/embedded-graphics-wii/build.rs
@@ -15,7 +15,7 @@ fn main() {
 	};
 	let output = libgcc_location.stdout;
 	let parsed_output =
-		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace("\n", "");
+		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace(&['\r', '\n'], "");
 		
 	let _ = match Command::new("powerpc-eabi-ar").arg("x").arg(parsed_output).arg("crtresxfpr.o").arg("crtresxgpr.o").output() {
 		Ok(output) => output,

--- a/examples/ios/build.rs
+++ b/examples/ios/build.rs
@@ -15,7 +15,7 @@ fn main() {
 	};
 	let output = libgcc_location.stdout;
 	let parsed_output =
-		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace("\n", "");
+		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace(&['\r', '\n'], "");
 		
 	let _ = match Command::new("powerpc-eabi-ar").arg("x").arg(parsed_output).arg("crtresxfpr.o").arg("crtresxgpr.o").output() {
 		Ok(output) => output,

--- a/examples/obj-loading/build.rs
+++ b/examples/obj-loading/build.rs
@@ -15,7 +15,7 @@ fn main() {
 	};
 	let output = libgcc_location.stdout;
 	let parsed_output =
-		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace("\n", "");
+		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace(&['\r', '\n'], "");
 		
 	let _ = match Command::new("powerpc-eabi-ar").arg("x").arg(parsed_output).arg("crtresxfpr.o").arg("crtresxgpr.o").output() {
 		Ok(output) => output,

--- a/examples/template/build.rs
+++ b/examples/template/build.rs
@@ -15,7 +15,7 @@ fn main() {
 	};
 	let output = libgcc_location.stdout;
 	let parsed_output =
-		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace("\n", "");
+		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace(&['\r', '\n'], "");
 		
 	let _ = match Command::new("powerpc-eabi-ar").arg("x").arg(parsed_output).arg("crtresxfpr.o").arg("crtresxgpr.o").output() {
 		Ok(output) => output,

--- a/examples/texture-tri/build.rs
+++ b/examples/texture-tri/build.rs
@@ -15,7 +15,7 @@ fn main() {
 	};
 	let output = libgcc_location.stdout;
 	let parsed_output =
-		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace("\n", "");
+		String::from_utf8(output).expect("powerpc-eabi-gcc command output returned a non-utf8 string.").replace(&['\r', '\n'], "");
 		
 	let _ = match Command::new("powerpc-eabi-ar").arg("x").arg(parsed_output).arg("crtresxfpr.o").arg("crtresxgpr.o").output() {
 		Ok(output) => output,


### PR DESCRIPTION
As discussed on #146, the build script in all templates fail to build on Windows due to the fact that while searching for libgcc.a, they call `gcc` and only strip line feed ('\n') characters from its output, but not carriage returns ('\r'). Since line termination on Windows is "\r\n", this is necessary, otherwise `ar` will then look for "libgcc.a\r", which does not exist.

Tested this fix on a Windows 11 VM with the latest devkitPro, latest rustc nightly and latest Clang+LLVM, now examples compile without issues.