### PR TITLE
Fix texture cache on real hardware

### DIFF
--- a/src/gx/mod.rs
+++ b/src/gx/mod.rs
@@ -879,6 +879,9 @@ impl<'a> Texture<'a> {
         assert!(width <= 1024, "max width for texture is 1024");
         assert!(height <= 1024, "max height for texture is 1024");
         unsafe {
+            cache::data_cache_flush(img);
+        }
+        unsafe {
             ffi::GX_InitTexObj(
                 texture.as_ptr() as *mut _,
                 img.as_ptr() as *mut _,
@@ -907,6 +910,9 @@ impl<'a> Texture<'a> {
         assert_eq!(0, img.as_ptr().align_offset(32));
         assert!(width <= 1024, "max width for texture is 1024");
         assert!(height <= 1024, "max height for texture is 1024");
+        unsafe {
+            cache::data_cache_flush(img);
+        }
         unsafe {
             ffi::GX_InitTexObjCI(
                 texture.as_ptr() as *mut _,


### PR DESCRIPTION
#150:

> ITS THE FUCKING DATA CACHE
> I HATE THE WIIS INSTRUCTION DATA CACHE

...yeah, the textures seem to need flushing too.

Before fix:

<img width="1008" height="756" alt="bad_tex jpg shrink" src="https://github.com/user-attachments/assets/6c3ca446-41d9-4710-9d37-e9d2e6a96d86" />

(kinda random which parts of the triangle went missing)

After fix:

<img width="1008" height="756" alt="good_tex jpg shrink" src="https://github.com/user-attachments/assets/647f0b1e-02f1-4b88-bbef-0d89bc31ef9a" />
