### PR TITLE
Create toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt", "rustc", "rust-src", "cargo", "rust-analyzer", "clippy" ]
+profile = "default"


### PR DESCRIPTION
Closes #165 

Rust toolchain file that Rustup should detect and automatically download the latest nightly toolchain and components.